### PR TITLE
Add QR code to invoice/proforma PDFs and fix layout

### DIFF
--- a/src/pages/Invoices.tsx
+++ b/src/pages/Invoices.tsx
@@ -47,7 +47,7 @@ import { EditInvoiceModal } from '@/components/invoices/EditInvoiceModal';
 import { ViewInvoiceModal } from '@/components/invoices/ViewInvoiceModal';
 import { RecordPaymentModal } from '@/components/payments/RecordPaymentModal';
 import { CreateDeliveryNoteModal } from '@/components/delivery/CreateDeliveryNoteModal';
-import { downloadInvoiceJsPDF } from '@/utils/jsPdfGenerator';
+import { downloadInvoicePDF } from '@/utils/pdfGenerator';
 
 interface Invoice {
   id: string;

--- a/src/pages/Invoices.tsx
+++ b/src/pages/Invoices.tsx
@@ -173,7 +173,7 @@ export default function Invoices() {
         logo_url: currentCompany.logo_url
       } : undefined;
 
-      downloadInvoiceJsPDF(invoice, 'INVOICE', companyDetails);
+      downloadInvoicePDF(invoice, 'INVOICE', companyDetails);
       toast.success(`PDF download started for ${invoice.invoice_number}`);
     } catch (error) {
       console.error('Error downloading PDF:', error);

--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -426,7 +426,7 @@ const buildDocumentHTML = (data: DocumentData) => {
     ${''}
 
     ${data.terms_and_conditions && (data.type === 'invoice' || data.type === 'proforma') ? `
-    <div class="invoice-terms-section" style="page-break-before: always;">
+    <div class="invoice-terms-section" style="page-break-inside: avoid;">
       <div class="invoice-terms">
         <div class="section-subtitle">Terms & Conditions</div>
         <div class="terms-content" style="max-height: 150mm; overflow: hidden;">${sanitizeAndEscape(data.terms_and_conditions || '')}</div>
@@ -1225,7 +1225,7 @@ export const generatePDF = (data: DocumentData) => {
 
         <!-- Terms Section (for invoices and proformas) -->
         ${data.terms_and_conditions && (data.type === 'invoice' || data.type === 'proforma') ? `
-        <div class="invoice-terms-section" style="page-break-before: always;">
+        <div class="invoice-terms-section" style="page-break-inside: avoid;">
           <div class="invoice-terms">
             <div class="section-subtitle">Terms & Conditions</div>
         <div class="terms-content" style="max-height: 150mm; overflow: hidden;">${sanitizeAndEscape(data.terms_and_conditions || '')}</div>

--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -244,6 +244,8 @@ const buildDocumentHTML = (data: DocumentData) => {
     .invoice-terms { width: 100%; padding: 20px; background: #f8f9fa; border-radius: 8px; border: 1px solid #e9ecef; margin-bottom: 20px; }
     .invoice-bank-details { margin-top: 12px; margin-bottom: 0; padding: 15px; background: #f0f0f0; border-radius: 8px; border: 1px solid #ddd; font-size: 10px; color: #111827; text-align: center; font-weight: 600; line-height: 1.4; page-break-inside: avoid; }
 .invoice-bank-details .bank-line { margin: 6px 0; }
+    .invoice-qr { display: flex; justify-content: center; align-items: center; margin: 10mm 0 6mm 0; }
+    .invoice-qr img { width: 25mm; height: 25mm; object-fit: contain; }
     .quotation-footer { position: absolute; left: 20mm; right: 20mm; bottom: 10mm; font-size: 12px; color: #111827; text-align: center; font-weight: 600; font-style: italic; }
   </style>
 </head>
@@ -427,11 +429,14 @@ const buildDocumentHTML = (data: DocumentData) => {
     <div class="invoice-terms-section" style="page-break-before: always;">
       <div class="invoice-terms">
         <div class="section-subtitle">Terms & Conditions</div>
-        <div class="terms-content">${sanitizeAndEscape(data.terms_and_conditions || '')}</div>
+        <div class="terms-content" style="max-height: 150mm; overflow: hidden;">${sanitizeAndEscape(data.terms_and_conditions || '')}</div>
       </div>
     </div>` : ''}
 
     ${(data.type === 'invoice' || data.type === 'proforma') ? `
+    <div class="invoice-qr">
+      <img src="https://cdn.builder.io/api/v1/image/assets%2Fff37486b4b4c4842b23aee857d4320a5%2Fe5bd57bc8bd94893b0fe529520b36c3f?format=webp&width=800" alt="Invoice QR Code" />
+    </div>
     <div class="invoice-bank-details">
       <div class="bank-line"><strong>MAKE ALL PAYMENTS THROUGH BIOLEGEND SCIENTIFIC LTD:</strong></div>
       <div class="bank-line">-KCB RIVER ROAD BRANCH NUMBER: 1216348367 - SWIFT CODE; KCBLKENX - BANK CODE; 01 - BRANCH CODE; 114</div>
@@ -1223,20 +1228,23 @@ export const generatePDF = (data: DocumentData) => {
         <div class="invoice-terms-section" style="page-break-before: always;">
           <div class="invoice-terms">
             <div class="section-subtitle">Terms & Conditions</div>
-        <div class="terms-content">${sanitizeAndEscape(data.terms_and_conditions || '')}</div>
+        <div class="terms-content" style="max-height: 150mm; overflow: hidden;">${sanitizeAndEscape(data.terms_and_conditions || '')}</div>
           </div>
         </div>
         ` : ''}
 
-        <!-- Bank Details (for invoices and proformas) -->
+        <!-- QR code between Terms and Bank details -->
         ${(data.type === 'invoice' || data.type === 'proforma') ? `
-    <div class="invoice-bank-details">
-      <div class="bank-line"><strong>MAKE ALL PAYMENTS THROUGH BIOLEGEND SCIENTIFIC LTD:</strong></div>
-      <div class="bank-line">-KCB RIVER ROAD BRANCH NUMBER: 1216348367 - SWIFT CODE; KCBLKENX - BANK CODE; 01 - BRANCH CODE; 114</div>
-      <div class="bank-line">-ABSA BANK KENYA PLC: THIKA ROAD MALL BRANCH, ACC: 2051129930, BRANCH CODE; 024, SWIFT CODE; BARCKENX</div>
-      <div class="bank-line">-NCBA BANK KENYA PLC: THIKA ROAD MALL (TRM) BRANCH, ACC: 1007470556, BANK CODE: 000, BRANCH CODE; 07, SWIFT CODE: CBAFKENX</div>
-    </div>
-    ` : ''}
+        <div class="invoice-qr">
+          <img src="https://cdn.builder.io/api/v1/image/assets%2Fff37486b4b4c4842b23aee857d4320a5%2Fe5bd57bc8bd94893b0fe529520b36c3f?format=webp&width=800" alt="Invoice QR Code" />
+        </div>
+        <div class="invoice-bank-details">
+          <div class="bank-line"><strong>MAKE ALL PAYMENTS THROUGH BIOLEGEND SCIENTIFIC LTD:</strong></div>
+          <div class="bank-line">-KCB RIVER ROAD BRANCH NUMBER: 1216348367 - SWIFT CODE; KCBLKENX - BANK CODE; 01 - BRANCH CODE; 114</div>
+          <div class="bank-line">-ABSA BANK KENYA PLC: THIKA ROAD MALL BRANCH, ACC: 2051129930, BRANCH CODE; 024, SWIFT CODE; BARCKENX</div>
+          <div class="bank-line">-NCBA BANK KENYA PLC: THIKA ROAD MALL (TRM) BRANCH, ACC: 1007470556, BANK CODE: 000, BRANCH CODE; 07, SWIFT CODE: CBAFKENX</div>
+        </div>
+        ` : ''}
 
 
       </div>

--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -245,7 +245,7 @@ const buildDocumentHTML = (data: DocumentData) => {
     .invoice-bank-details { margin-top: 12px; margin-bottom: 0; padding: 15px; background: #f0f0f0; border-radius: 8px; border: 1px solid #ddd; font-size: 10px; color: #111827; text-align: center; font-weight: 600; line-height: 1.4; page-break-inside: avoid; }
 .invoice-bank-details .bank-line { margin: 6px 0; }
     .invoice-qr { display: flex; justify-content: center; align-items: center; margin: 10mm 0 6mm 0; }
-    .invoice-qr img { width: 25mm; height: 25mm; object-fit: contain; }
+    .invoice-qr img { width: 40mm; height: 40mm; object-fit: contain; }
     .quotation-footer { position: absolute; left: 20mm; right: 20mm; bottom: 10mm; font-size: 12px; color: #111827; text-align: center; font-weight: 600; font-style: italic; }
   </style>
 </head>

--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -125,7 +125,7 @@ const buildDocumentHTML = (data: DocumentData) => {
   const company = data.company || DEFAULT_COMPANY;
   const visibleColumns = (() => {
     const cols: any = analyzeColumns(data.items);
-    if (data.type === 'quotation' || data.type === 'invoice') {
+    if (data.type === 'quotation' || data.type === 'invoice' || data.type === 'proforma') {
       cols.taxPercentage = false;
       cols.taxAmount = false;
       cols.discountPercentage = false;
@@ -242,7 +242,7 @@ const buildDocumentHTML = (data: DocumentData) => {
     .bank-details { position: absolute; left: 20mm; right: 20mm; bottom: 10mm; font-size: 10px; color: #111827; text-align: center; font-weight: 600; }
     .invoice-terms-section { margin: 30px 0 20px 0; page-break-inside: avoid; }
     .invoice-terms { width: 100%; padding: 20px; background: #f8f9fa; border-radius: 8px; border: 1px solid #e9ecef; margin-bottom: 20px; }
-    .invoice-bank-details { margin-top: 12px; margin-bottom: 0; padding: 0; background: transparent; border-radius: 0; border: none; font-size: 10px; color: #111827; text-align: left; font-weight: 600; line-height: 1.4; page-break-inside: avoid; }
+    .invoice-bank-details { margin-top: 12px; margin-bottom: 0; padding: 15px; background: #f0f0f0; border-radius: 8px; border: 1px solid #ddd; font-size: 10px; color: #111827; text-align: center; font-weight: 600; line-height: 1.4; page-break-inside: avoid; }
 .invoice-bank-details .bank-line { margin: 6px 0; }
     .quotation-footer { position: absolute; left: 20mm; right: 20mm; bottom: 10mm; font-size: 12px; color: #111827; text-align: center; font-weight: 600; font-style: italic; }
   </style>
@@ -454,7 +454,7 @@ export const generatePDF = (data: DocumentData) => {
   // Analyze which columns have values
   const visibleColumns = (() => {
     const cols: any = analyzeColumns(data.items);
-    if (data.type === 'quotation' || data.type === 'invoice') {
+    if (data.type === 'quotation' || data.type === 'invoice' || data.type === 'proforma') {
       cols.taxPercentage = false;
       cols.taxAmount = false;
       cols.discountPercentage = false;
@@ -1299,14 +1299,18 @@ export const generatePDFDownload = async (data: DocumentData) => {
   const pageHeight = pdf.internal.pageSize.getHeight();
 
   // Footer reservation (mm) for types that require a persistent bottom footer
-  const footerReserveMm = data.type === 'quotation' ? 18 : 0; // space to keep free at bottom
+  const footerReserveMm = (data.type === 'quotation' || data.type === 'invoice' || data.type === 'proforma') ? 18 : 0; // space to keep free at bottom
 
   // Helper to draw footer on each page
   const drawFooter = (pageIndex: number) => {
-    if (data.type !== 'quotation') return;
+    if (data.type !== 'quotation' && data.type !== 'invoice' && data.type !== 'proforma') return;
     const marginMm = 20;
     const maxWidth = pageWidth - marginMm * 2;
-    const text = 'We trust that you will look at this quote satisfactorily........, looking forward to the order. Thank you for Your business!';
+    const text = data.type === 'quotation'
+      ? 'We trust that you will look at this quote satisfactorily........, looking forward to the order. Thank you for Your business!'
+      : data.type === 'invoice'
+      ? 'Thank you for your business. Please remit payment to the bank details below by the due date.'
+      : 'This is a proforma invoice. Payment confirms order. Thank you for your business.';
     pdf.setFont('helvetica', 'italic');
     pdf.setFontSize(10);
     pdf.setTextColor(17, 24, 39);


### PR DESCRIPTION
## Purpose
Based on the conversation history, the user requested several improvements to invoice and proforma PDF generation:
- Audit and standardize PDF designs across quotations, invoices, and proforma invoices
- Insert a QR code uniformly between terms and bank details sections
- Fix blank page issues in proforma PDFs
- Enlarge the QR code size for better visibility
- Maintain existing formatting and ensure content fits on one page

## Code changes
- **PDF Generator Updates**: Modified `pdfGenerator.ts` to include QR code rendering between terms and bank details for invoices and proforma invoices
- **QR Code Integration**: Added QR code image with proper sizing (40mm x 40mm) and centered positioning
- **Layout Improvements**: 
  - Removed forced page breaks (`page-break-before: always`) to prevent blank pages
  - Added `page-break-inside: avoid` to keep sections together
  - Enhanced bank details styling with background and border
  - Added max-height constraint for terms content to prevent overflow
- **Function Renaming**: Updated import from `downloadInvoiceJsPDF` to `downloadInvoicePDF` in `Invoices.tsx`
- **Proforma Support**: Extended column visibility logic and footer handling to include proforma invoices
- **Footer Enhancements**: Added type-specific footer text for invoices and proforma invoicesTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1c37ef00a17840a0a88a38c50e187ec7/glow-haven)

👀 [Preview Link](https://1c37ef00a17840a0a88a38c50e187ec7-glow-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1c37ef00a17840a0a88a38c50e187ec7</projectId>-->
<!--<branchName>glow-haven</branchName>-->