### PR TITLE
Fix invoice currency conversion and exchange rate locking

### DIFF
--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -1501,7 +1501,7 @@ export const downloadInvoicePDF = async (invoice: any, documentType: 'INVOICE' |
     paid_amount: invoice.paid_amount || 0,
     balance_due: invoice.balance_due || (invoice.total_amount - (invoice.paid_amount || 0)),
     notes: invoice.notes,
-    currency_code: invoice.currency_code || 'KES',
+    currency_code: (invoice.currency_code === 'USD' || invoice.currency_code === 'KES' ? invoice.currency_code : (Number(invoice.exchange_rate) && Number(invoice.exchange_rate) !== 1 ? 'USD' : 'KES')),
     terms_and_conditions: (documentType === 'INVOICE' || documentType === 'PROFORMA') ? `Terms
 1. PAYMENT.
 Payment terms are cash on delivery, unless credit terms are established at the Seller��s sole discretion. Buyer agrees to pay Seller cost of collection of overdue invoices, including reasonable attorney���s fees. Net 30 days on all credit invoices or “Month Following invoice”. In addition, Buyer shall pay all sales, use, customs, excise or other taxes presently or hereafter payable in regards to this transaction, and Buyer shall reimburse Seller for any such taxes or charges paid by BIOLEGEND SCIENTIFIC LTD (hereafter "Seller."). Including all withholding taxes which should be remitted immediately upon payments.


### PR DESCRIPTION
## Purpose
The user was auditing invoice BIO-INV-2025-0015 and encountered issues with currency conversion and exchange rates. They expected values displayed in the create modal to appear correctly in the PDF with automatic currency conversion applied for the invoice date. The system needed to create records using the current exchange rate at the time of creation and ensure proper currency handling throughout the invoice workflow.

## Code changes
- **Invoice Creation**: Added exchange rate locking mechanism that fetches and applies the correct rate for USD invoices at creation time
- **Currency Conversion**: Implemented automatic adjustment of invoice items (unit_price, tax_amount, line_total) and totals (subtotal, tax_amount, total_amount) based on the locked exchange rate
- **Rate Calculation**: Added logic to calculate conversion factor and apply it consistently across all monetary values when currency is USD
- **PDF Generation**: Enhanced currency code detection logic to properly handle USD/KES currency display in generated PDFs
- **Data Integrity**: Ensured exchange rate is properly stored with the invoice record for future referenceTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 9`

🔗 [Edit in Builder.io](https://builder.io/app/projects/9f08d6af140e4958be4bd34096b2cd2e/cosmos-haven)

👀 [Preview Link](https://9f08d6af140e4958be4bd34096b2cd2e-cosmos-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9f08d6af140e4958be4bd34096b2cd2e</projectId>-->
<!--<branchName>cosmos-haven</branchName>-->