### PR TITLE
Inherit currency from quotation when converting to invoice

### DIFF
--- a/src/hooks/useQuotationItems.ts
+++ b/src/hooks/useQuotationItems.ts
@@ -209,9 +209,9 @@ export const useConvertQuotationToInvoice = () => {
         notes: quotation.notes,
         terms_and_conditions: quotation.terms_and_conditions,
         affects_inventory: true,
-        currency_code: (quotation as any).currency_code ?? 'KES',
-        exchange_rate: (quotation as any).exchange_rate ?? 1,
-        fx_date: (quotation as any).quotation_date ?? new Date().toISOString().split('T')[0]
+        currency_code: (quotation as any).currency_code,
+        exchange_rate: (quotation as any).exchange_rate || 1,
+        fx_date: (quotation as any).quotation_date || new Date().toISOString().split('T')[0]
       };
       
       const { data: invoice, error: invoiceError } = await supabase


### PR DESCRIPTION
### Summary
Ensures that when a quotation is converted to an invoice, the currency code is properly inherited from the quotation without being overridden by a default value.

### Problem
When converting a quotation with a non-default currency (e.g., USD) to an invoice, the invoice was falling back to `'KES'` as the default currency code due to the `??` nullish coalescing operator. This caused the generated invoice PDF to display the wrong currency instead of the one set on the original quotation.

### Solution
Removed the hardcoded `'KES'` fallback for `currency_code` so the value is taken directly from the quotation. The `exchange_rate` and `fx_date` fields are updated to use `||` instead of `??` to correctly handle falsy values while still providing sensible defaults.

### Key Changes
- **`currency_code`**: Removed the `?? 'KES'` fallback — the quotation's currency code is now passed through as-is.
- **`exchange_rate`**: Changed from `?? 1` to `|| 1` to handle falsy (e.g., `0`) values with a default of `1`.
- **`fx_date`**: Changed from `?? new Date()...` to `|| new Date()...` for consistent falsy-value handling.


---

<a href="https://builder.io/app/projects/15b3a05ee9a74438a34c/basic-disk-jfl6popg"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://15b3a05ee9a74438a34c-basic-disk-jfl6popg.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=15b3a05ee9a74438a34c&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 56`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>15b3a05ee9a74438a34c</projectId>-->
<!--<branchName>basic-disk-jfl6popg</branchName>-->