### PR TITLE
Fix invoice PDF missing line items and currency display

### DIFF
--- a/src/pages/Invoices.tsx
+++ b/src/pages/Invoices.tsx
@@ -163,8 +163,8 @@ export default function Invoices() {
   }) || [];
 
   const displayAmount = (amount: number, recordCurrency?: 'KES' | 'USD', invoiceRate?: number) => {
-    const normalized = normalizeInvoiceAmount(Number(amount) || 0, recordCurrency as any, invoiceRate as any, currency, rate);
-    return format(normalized, currency);
+    const invoiceCurrency = (recordCurrency === 'USD' || recordCurrency === 'KES') ? recordCurrency : 'KES';
+    return format(Number(amount) || 0, invoiceCurrency);
   };
 
 

--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -3,6 +3,7 @@ import html2canvas from 'html2canvas';
 import { sanitizeAndEscape } from './textSanitizer';
 import { getLocaleForCurrency } from './exchangeRates';
 import { formatCurrency as formatCurrencyUtil } from '@/utils/formatCurrency';
+import { supabase } from '@/integrations/supabase/client';
 
 // PDF Generation utility using HTML to print/PDF conversion
 // Since we don't have jsPDF installed, I'll create a simple HTML-to-print function
@@ -1519,6 +1520,32 @@ export const generatePDFDownload = async (data: DocumentData) => {
 
 // Specific function for invoice PDF generation
 export const downloadInvoicePDF = async (invoice: any, documentType: 'INVOICE' | 'PROFORMA' = 'INVOICE', company?: CompanyDetails) => {
+  let invoiceItems = invoice.invoice_items;
+
+  if (!invoiceItems || invoiceItems.length === 0) {
+    try {
+      const { data, error } = await supabase
+        .from('invoice_items')
+        .select(`
+          *,
+          products (
+            id,
+            name,
+            description,
+            product_code,
+            unit_of_measure
+          )
+        `)
+        .eq('invoice_id', invoice.id);
+
+      if (!error && data) {
+        invoiceItems = data;
+      }
+    } catch (err) {
+      console.error('Error fetching invoice items:', err);
+    }
+  }
+
   const documentData: DocumentData = {
     type: documentType === 'PROFORMA' ? 'proforma' : 'invoice',
     number: invoice.invoice_number,
@@ -1534,7 +1561,7 @@ export const downloadInvoicePDF = async (invoice: any, documentType: 'INVOICE' |
       city: invoice.customers?.city,
       country: invoice.customers?.country,
     },
-    items: invoice.invoice_items?.map((item: any, index: number) => {
+    items: invoiceItems?.map((item: any, index: number) => {
       const quantity = Number(item.quantity || 0);
       const unitPrice = Number(item.unit_price || 0);
       const taxAmount = Number(item.tax_amount || 0);


### PR DESCRIPTION
### Summary
This PR fixes two bugs in invoice handling: missing line items in downloaded invoice PDFs and incorrect currency display (KES instead of USD) in the invoice list.

### Problem
When converting a USD quotation to an invoice, the resulting invoice had two issues:
1. The downloaded PDF contained no line items, because `invoice_items` were not always eagerly loaded on the invoice object passed to the PDF generator.
2. The invoice list displayed amounts in KES regardless of the invoice's actual currency, because the display logic was normalizing amounts through an exchange-rate conversion instead of simply formatting in the invoice's own currency.

### Solution
- In `downloadInvoicePDF`, fall back to a direct Supabase query to fetch `invoice_items` (with product details) when they are absent from the invoice object, ensuring the PDF always has line items to render.
- In `Invoices.tsx`, simplify `displayAmount` to format the raw amount directly in the invoice's own currency (`USD` or `KES`) rather than running it through `normalizeInvoiceAmount`, which was incorrectly converting amounts.

### Key Changes
- **`src/utils/pdfGenerator.ts`**: Added a Supabase fallback fetch for `invoice_items` (including related `products`) inside `downloadInvoicePDF` when the invoice object carries no items. Imports `supabase` client for this purpose.
- **`src/pages/Invoices.tsx`**: Replaced the `normalizeInvoiceAmount` + `format` pipeline in `displayAmount` with a direct `format(amount, invoiceCurrency)` call, preserving the invoice's original currency code.


---

<a href="https://builder.io/app/projects/b40b258189b744db9f23/cinder-mouth-x7nlhmi1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://b40b258189b744db9f23-cinder-mouth-x7nlhmi1.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=b40b258189b744db9f23&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 57`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b40b258189b744db9f23</projectId>-->
<!--<branchName>cinder-mouth-x7nlhmi1</branchName>-->