### PR TITLE
Fix currency display in quotations list and view modal

### DIFF
--- a/src/components/quotations/ViewQuotationModal.tsx
+++ b/src/components/quotations/ViewQuotationModal.tsx
@@ -54,7 +54,14 @@ export function ViewQuotationModal({
 
   // Call currency hook unconditionally to preserve hooks order
   const { currency, rate, format } = useCurrency();
-  const formatQuotationAmount = (amount: number) => format(Number(amount) || 0, quotation.currency_code as any);
+  const formatQuotationAmount = (amount: number) => {
+    // Handle currency code detection: if exchange_rate != 1, it's likely USD even if currency_code says KES
+    let effectiveCurrency = quotation?.currency_code || 'KES';
+    if (effectiveCurrency === 'KES' && quotation?.exchange_rate && quotation.exchange_rate !== 1) {
+      effectiveCurrency = 'USD';
+    }
+    return format(Number(amount) || 0, effectiveCurrency as any);
+  };
 
   if (!quotation) return null;
 

--- a/src/components/quotations/ViewQuotationModal.tsx
+++ b/src/components/quotations/ViewQuotationModal.tsx
@@ -261,6 +261,22 @@ export function ViewQuotationModal({
                   </div>
                 )}
                 <div className="flex justify-between">
+                  <span className="text-muted-foreground">Currency:</span>
+                  <span className="font-semibold">
+                    {(() => {
+                      const currency = quotation.currency_code || 'KES';
+                      const effectiveCurrency = currency === 'KES' && quotation.exchange_rate && quotation.exchange_rate !== 1 ? 'USD' : currency;
+                      return effectiveCurrency === 'USD' ? 'USD (US Dollar)' : 'KES (Kenyan Shilling)';
+                    })()}
+                  </span>
+                </div>
+                {quotation.exchange_rate && quotation.exchange_rate !== 1 && (
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground">Exchange Rate:</span>
+                    <span>{quotation.exchange_rate.toFixed(6)}</span>
+                  </div>
+                )}
+                <div className="flex justify-between">
                   <span className="text-muted-foreground">Total Amount:</span>
                   <span className="font-semibold text-primary">{formatQuotationAmount(quotation.total_amount || 0)}</span>
                 </div>

--- a/src/pages/Quotations.tsx
+++ b/src/pages/Quotations.tsx
@@ -126,7 +126,15 @@ export default function Quotations() {
   const deleteQuotation = useDeleteQuotation();
 
   const { currency, rate, format } = useCurrency();
-  const formatQuotationAmount = (amount: number, quotationCurrency: string) => format(Number(amount) || 0, quotationCurrency as any);
+  const formatQuotationAmount = (amount: number, quotationCurrency: string, exchangeRate?: number) => {
+    // Handle currency code detection: if exchange_rate != 1, it's likely USD even if currency_code says KES
+    let effectiveCurrency = quotationCurrency;
+    if (quotationCurrency === 'KES' && exchangeRate && exchangeRate !== 1) {
+      // Quotation was created with USD but stored with wrong currency_code
+      effectiveCurrency = 'USD';
+    }
+    return format(Number(amount) || 0, effectiveCurrency as any);
+  };
 
   const filteredQuotations = quotations?.filter(quotation =>
     quotation.customers?.name?.toLowerCase().includes(searchTerm.toLowerCase())
@@ -509,7 +517,7 @@ Website: www.biolegendscientific.co.ke`;
                       </div>
                     </TableCell>
                     <TableCell className="font-semibold">
-                      {formatQuotationAmount(quotation.total_amount || 0, quotation.currency_code || 'KES')}
+                      {formatQuotationAmount(quotation.total_amount || 0, quotation.currency_code || 'KES', quotation.exchange_rate)}
                     </TableCell>
                     <TableCell>
                       {quotation.valid_until 


### PR DESCRIPTION
### Summary
Fixes incorrect currency display in the quotations list and view modal, where USD quotations were being shown with KES (KSh) formatting. Also adds currency and exchange rate fields to the quotation view modal.

### Problem
Quotations created in USD were being displayed with KES formatting in both the quotations list table and the view modal. This happened because the stored `currency_code` was `KES` even for USD transactions, causing all amounts to render with the wrong currency symbol.

### Solution
Detect the effective currency by inspecting the `exchange_rate` field: if `currency_code` is `KES` but `exchange_rate` is not `1`, the quotation was created in USD. The formatting logic now uses this heuristic to apply the correct currency symbol.

### Key Changes
- **`src/pages/Quotations.tsx`**: Updated `formatQuotationAmount` to accept an optional `exchangeRate` parameter and detect USD quotations stored with a `KES` currency code; passes `quotation.exchange_rate` when rendering amounts in the table.
- **`src/components/quotations/ViewQuotationModal.tsx`**: Applied the same exchange-rate-based currency detection to `formatQuotationAmount` in the view modal.
- **`src/components/quotations/ViewQuotationModal.tsx`**: Added a **Currency** field (e.g., `USD (US Dollar)` / `KES (Kenyan Shilling)`) and an **Exchange Rate** field (shown only when rate ≠ 1) to the quotation details panel.


---

<a href="https://builder.io/app/projects/087ea86bffc34d16b094/calm-log-nh1hpsza"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://087ea86bffc34d16b094-calm-log-nh1hpsza.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=087ea86bffc34d16b094&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 62`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>087ea86bffc34d16b094</projectId>-->
<!--<branchName>calm-log-nh1hpsza</branchName>-->