### PR TITLE
Show locked USD exchange rate on invoices

### DIFF
--- a/src/components/invoices/CreateInvoiceModal.tsx
+++ b/src/components/invoices/CreateInvoiceModal.tsx
@@ -931,6 +931,11 @@ export function CreateInvoiceModal({ open, onOpenChange, onSuccess, preSelectedC
                       <span>Items: {items.length}</span>
                       <span>Balance Due: {formatCurrency(balanceDue)}</span>
                     </div>
+                    {currencyCode === 'USD' && Number.isFinite(exchangeRate) && exchangeRate > 0 && (
+                      <div className="mt-3 p-2 bg-blue-50 border border-blue-200 rounded text-xs text-blue-700">
+                        ℹ️ Amounts converted at locked rate: 1 USD = {exchangeRate.toFixed(2)} KES (on {invoiceDate})
+                      </div>
+                    )}
                   </div>
                 </div>
               </div>

--- a/src/components/invoices/ViewInvoiceModal.tsx
+++ b/src/components/invoices/ViewInvoiceModal.tsx
@@ -301,6 +301,11 @@ export function ViewInvoiceModal({
                       {formatCurrency(invoice.balance_due || 0)}
                     </span>
                   </div>
+                  {invoice.currency_code === 'USD' && Number.isFinite(invoice.exchange_rate) && invoice.exchange_rate > 0 && (
+                    <div className="mt-3 p-2 bg-blue-50 border border-blue-200 rounded text-xs text-blue-700">
+                      ℹ️ Created at rate: 1 USD = {invoice.exchange_rate.toFixed(2)} KES (on {new Date(invoice.fx_date).toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' })})
+                    </div>
+                  )}
                 </div>
               </div>
             </div>

--- a/src/pages/Invoices.tsx
+++ b/src/pages/Invoices.tsx
@@ -163,8 +163,14 @@ export default function Invoices() {
   }) || [];
 
   const displayAmount = (amount: number, recordCurrency?: 'KES' | 'USD', invoiceRate?: number) => {
-    const invoiceCurrency = (recordCurrency === 'USD' || recordCurrency === 'KES') ? recordCurrency : 'KES';
-    return format(Number(amount) || 0, invoiceCurrency);
+    const normalized = normalizeInvoiceAmount(
+      Number(amount) || 0,
+      recordCurrency,
+      invoiceRate,
+      currency,
+      rate
+    );
+    return format(normalized, currency);
   };
 
 

--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -56,6 +56,8 @@ export interface DocumentData {
   valid_until?: string; // For proforma invoices
   due_date?: string; // For invoices
   currency_code?: 'KES' | 'USD';
+  exchange_rate?: number;
+  fx_date?: string;
   // Delivery note specific fields
   delivery_date?: string;
   delivery_address?: string;
@@ -1254,6 +1256,11 @@ export const generatePDF = (data: DocumentData) => {
             </tr>
             ` : ''}
           </table>
+          ${data.currency_code === 'USD' && Number.isFinite(data.exchange_rate) && data.exchange_rate > 0 ? `
+          <div style="margin-top: 12px; padding: 8px; background: #dbeafe; border: 1px solid #60a5fa; border-radius: 4px; font-size: 11px; color: #1e40af;">
+            ℹ️ Created at rate: 1 USD = ${data.exchange_rate.toFixed(2)} KES (on ${data.fx_date ? new Date(data.fx_date).toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' }) : 'N/A'})
+          </div>
+          ` : ''}
         </div>
         ` : ''}
 
@@ -1597,6 +1604,8 @@ export const downloadInvoicePDF = async (invoice: any, documentType: 'INVOICE' |
     balance_due: invoice.balance_due || (invoice.total_amount - (invoice.paid_amount || 0)),
     notes: invoice.notes,
     currency_code: (invoice.currency_code === 'USD' || invoice.currency_code === 'KES' ? invoice.currency_code : (Number(invoice.exchange_rate) && Number(invoice.exchange_rate) !== 1 ? 'USD' : 'KES')),
+    exchange_rate: invoice.exchange_rate,
+    fx_date: invoice.fx_date,
     terms_and_conditions: (documentType === 'INVOICE' || documentType === 'PROFORMA') ? `Terms
 1. PAYMENT.
 Payment terms are cash on delivery, unless credit terms are established at the Seller��s sole discretion. Buyer agrees to pay Seller cost of collection of overdue invoices, including reasonable attorney���s fees. Net 30 days on all credit invoices or “Month Following invoice”. In addition, Buyer shall pay all sales, use, customs, excise or other taxes presently or hereafter payable in regards to this transaction, and Buyer shall reimburse Seller for any such taxes or charges paid by BIOLEGEND SCIENTIFIC LTD (hereafter "Seller."). Including all withholding taxes which should be remitted immediately upon payments.


### PR DESCRIPTION
### Summary
This PR ensures that USD invoices display the locked exchange rate (1 USD = X KES) at the time of creation across the invoice list, create modal, view modal, and generated PDFs.

### Problem
Invoice amounts saved in USD were not being converted using the locked exchange rate. The invoice list, PDF, edit modal, and create modal all failed to reflect the correct converted amounts or communicate the rate at which the invoice was created, causing confusion and potential financial discrepancies.

### Solution
The `displayAmount` utility in the invoice list now uses a `normalizeInvoiceAmount` helper to correctly convert amounts based on the invoice's locked rate and the current display currency. A rate info banner (showing `1 USD = X KES` on the invoice date) was added to the create modal, view modal, and generated PDF for USD invoices.

### Key Changes
- **`Invoices.tsx`**: Updated `displayAmount` to call `normalizeInvoiceAmount` with the invoice's locked `exchange_rate` and current display currency, replacing the previous naive currency pass-through.
- **`CreateInvoiceModal.tsx`**: Added an informational blue banner showing the locked exchange rate when the invoice currency is USD.
- **`ViewInvoiceModal.tsx`**: Added the same rate info banner to the view/detail modal for USD invoices, using the stored `exchange_rate` and `fx_date`.
- **`pdfGenerator.ts`**: Extended `DocumentData` interface with `exchange_rate` and `fx_date` fields; added a rate info block to the PDF output for USD invoices; passed these fields through in `downloadInvoicePDF`.

---

<a href="https://builder.io/app/projects/76b68a56c2b04be8857c/peace-finger-cfzcs6t1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://76b68a56c2b04be8857c-peace-finger-cfzcs6t1.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=76b68a56c2b04be8857c&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 63`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>76b68a56c2b04be8857c</projectId>-->
<!--<branchName>peace-finger-cfzcs6t1</branchName>-->