### PR TITLE
Fix invoice rate recalculation using KES factor

### DIFF
--- a/src/components/invoices/EditInvoiceModal.tsx
+++ b/src/components/invoices/EditInvoiceModal.tsx
@@ -372,18 +372,20 @@ export function EditInvoiceModal({ open, onOpenChange, onSuccess, invoice }: Edi
 
       const factor = currentRate / lockedRateInfo.rate;
 
-      // Convert all item amounts from the old rate to the new rate
+      // Amounts in the form are stored in KES. To recalculate:
+      // 1. Convert KES back to USD using the old rate: USD = KES / oldRate
+      // 2. Convert USD to KES using the new rate: newKES = USD * newRate
+      // This is equivalent to: newKES = KES * (newRate / oldRate) = KES * factor
       const recalculatedItems = items.map(item => {
         const newUnitPrice = parseFloat((item.unit_price * factor).toFixed(4));
-        const { lineTotal, taxAmount } = calculateLineTotal(
-          { ...item, unit_price: newUnitPrice },
-          item.quantity
-        );
+        const newTaxAmount = parseFloat(((item.tax_amount || 0) * factor).toFixed(4));
+        const newLineTotal = parseFloat((item.line_total * factor).toFixed(4));
+
         return {
           ...item,
           unit_price: newUnitPrice,
-          line_total: lineTotal,
-          tax_amount: taxAmount
+          tax_amount: newTaxAmount,
+          line_total: newLineTotal
         };
       });
 


### PR DESCRIPTION
### Summary
Fixes the exchange rate recalculation logic in the Edit Invoice modal so that KES-stored amounts are correctly scaled when a user opts to recalculate with a new rate.

### Problem
When editing a USD invoice and choosing to recalculate with the current exchange rate, the previous logic re-derived line totals and tax amounts by calling `calculateLineTotal()` on the new unit price. This was incorrect because amounts are stored in KES, not USD — re-running the line total calculation from the unit price alone did not properly account for the original KES basis, leading to inaccurate recalculated totals.

### Solution
Replace the `calculateLineTotal()` call with a direct proportional scaling approach. Since all amounts are stored in KES, the recalculation multiplies each KES amount (unit price, tax amount, line total) by the factor `newRate / oldRate`, which is mathematically equivalent to converting KES → USD at the old rate and then USD → KES at the new rate.

### Key Changes
- **`EditInvoiceModal.tsx`**: Recalculation now scales `unit_price`, `tax_amount`, and `line_total` directly by the rate factor (`currentRate / lockedRate`) instead of re-deriving them via `calculateLineTotal()`.
- Added inline comments explaining the two-step conversion logic (KES → USD → KES) to clarify the intent for future maintainers.


---

<a href="https://builder.io/app/projects/6e979d0ccb3047fc90a0/omega-speed-ew0ps926"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://6e979d0ccb3047fc90a0-omega-speed-ew0ps926.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=6e979d0ccb3047fc90a0&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 65`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>6e979d0ccb3047fc90a0</projectId>-->
<!--<branchName>omega-speed-ew0ps926</branchName>-->