### PR TITLE
Fix exchange rate when converting quotation to invoice

### DIFF
--- a/src/hooks/useQuotationItems.ts
+++ b/src/hooks/useQuotationItems.ts
@@ -195,6 +195,7 @@ export const useConvertQuotationToInvoice = () => {
       });
       
       // Create invoice from quotation
+      const quotationRate = (quotation as any).exchange_rate || 1;
       const invoiceData = {
         company_id: quotation.company_id,
         customer_id: quotation.customer_id,
@@ -210,7 +211,7 @@ export const useConvertQuotationToInvoice = () => {
         terms_and_conditions: quotation.terms_and_conditions,
         affects_inventory: true,
         currency_code: (quotation as any).currency_code,
-        exchange_rate: (quotation as any).exchange_rate || 1,
+        exchange_rate: quotationRate ? (1 / quotationRate) : 1,
         fx_date: (quotation as any).quotation_date || new Date().toISOString().split('T')[0]
       };
       

--- a/src/pages/Quotations.tsx
+++ b/src/pages/Quotations.tsx
@@ -347,7 +347,7 @@ Website: www.biolegendscientific.co.ke`;
         invoiceDate: new Date().toISOString().split('T')[0],
         dueDate: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0],
         currencyCode: quotation.currency_code || 'KES',
-        exchangeRate: quotation.exchange_rate || 1
+        exchangeRate: quotation.exchange_rate ? (1 / quotation.exchange_rate) : 1
       };
 
       console.log('💾 Setting invoice prefill:', invoicePrefillData);

--- a/src/pages/Quotations.tsx
+++ b/src/pages/Quotations.tsx
@@ -347,7 +347,7 @@ Website: www.biolegendscientific.co.ke`;
         invoiceDate: new Date().toISOString().split('T')[0],
         dueDate: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0],
         currencyCode: quotation.currency_code || 'KES',
-        exchangeRate: quotation.exchange_rate ? (1 / quotation.exchange_rate) : 1
+        exchangeRate: quotation.exchange_rate || 1
       };
 
       console.log('💾 Setting invoice prefill:', invoicePrefillData);


### PR DESCRIPTION
### Summary
Fixes an incorrect exchange rate calculation when converting a quotation to an invoice, which caused amounts to be recalculated incorrectly.

### Problem
When a quotation created in a foreign currency (e.g., USD) was converted to an invoice, the system reapplied the exchange rate instead of preserving the original amounts. This caused the invoice values to be recalculated as if they were in the base currency (Ksh), resulting in incorrect totals.

### Solution
The quotation's exchange rate is now inverted (`1 / quotationRate`) when passed to the invoice, ensuring the conversion correctly reflects the original currency amounts without double-applying the rate.

### Key Changes
- Extracted `quotationRate` from the quotation's `exchange_rate` field before constructing the invoice payload.
- Changed `exchange_rate` on the invoice from `quotation.exchange_rate || 1` to `quotationRate ? (1 / quotationRate) : 1`, inverting the rate to preserve correct currency amounts during conversion.


---

<a href="https://builder.io/app/projects/c383cc4995ff4c8c9bd8/electric-compound-ueuszjbw"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://c383cc4995ff4c8c9bd8-electric-compound-ueuszjbw.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=c383cc4995ff4c8c9bd8&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 67`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c383cc4995ff4c8c9bd8</projectId>-->
<!--<branchName>electric-compound-ueuszjbw</branchName>-->