### PR TITLE
Fix invoice currency display and prevent double-conversion

### DIFF
--- a/src/components/invoices/EditInvoiceModal.tsx
+++ b/src/components/invoices/EditInvoiceModal.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useCurrency } from '@/contexts/CurrencyContext';
+import { normalizeInvoiceAmount } from '@/utils/currency';
 import { getLocaleForCurrency, getExchangeRate } from '@/utils/exchangeRates';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -61,16 +62,23 @@ interface EditInvoiceModalProps {
 }
 
 export function EditInvoiceModal({ open, onOpenChange, onSuccess, invoice }: EditInvoiceModalProps) {
-  const { format } = useCurrency();
+  const { currency, rate } = useCurrency();
 
   const formatInvoiceCurrency = (amount: number) => {
-    const currencyCode = invoice?.currency_code || 'KES';
-    return new Intl.NumberFormat(getLocaleForCurrency(currencyCode as any), {
+    const invoiceCurrency = invoice?.currency_code || 'KES';
+    const normalized = normalizeInvoiceAmount(
+      amount,
+      invoiceCurrency as any,
+      invoice?.exchange_rate,
+      invoiceCurrency as any,
+      rate
+    );
+    return new Intl.NumberFormat(getLocaleForCurrency(invoiceCurrency as any), {
       style: 'currency',
-      currency: currencyCode,
+      currency: invoiceCurrency,
       minimumFractionDigits: 0,
       maximumFractionDigits: 0,
-    }).format(Number.isFinite(amount) ? amount : 0);
+    }).format(Number.isFinite(normalized) ? normalized : 0);
   };
   const [selectedCustomerId, setSelectedCustomerId] = useState('');
   const [invoiceDate, setInvoiceDate] = useState('');

--- a/src/components/invoices/ViewInvoiceModal.tsx
+++ b/src/components/invoices/ViewInvoiceModal.tsx
@@ -47,10 +47,14 @@ export function ViewInvoiceModal({
 }: ViewInvoiceModalProps) {
   if (!invoice) return null;
 
-  const { currency, rate, format } = useCurrency();
-  const formatCurrency = (amount: number) => format(
-    normalizeInvoiceAmount(Number(amount) || 0, invoice?.currency_code as any, invoice?.exchange_rate as any, currency, rate)
-  );
+  const { rate, format } = useCurrency();
+  const formatCurrency = (amount: number) => {
+    const invoiceCurrency = invoice?.currency_code || 'KES';
+    return format(
+      normalizeInvoiceAmount(Number(amount) || 0, invoice?.currency_code as any, invoice?.exchange_rate as any, invoiceCurrency as any, rate),
+      invoiceCurrency as any
+    );
+  };
 
   const formatDate = (dateString: string) => {
     return new Date(dateString).toLocaleDateString('en-GB', {

--- a/src/pages/Invoices.tsx
+++ b/src/pages/Invoices.tsx
@@ -163,14 +163,16 @@ export default function Invoices() {
   }) || [];
 
   const displayAmount = (amount: number, recordCurrency?: 'KES' | 'USD', invoiceRate?: number) => {
+    // Display in the invoice's original currency, not the UI's current currency
+    const displayCurrency = (recordCurrency === 'USD' || recordCurrency === 'KES') ? recordCurrency : 'KES';
     const normalized = normalizeInvoiceAmount(
       Number(amount) || 0,
       recordCurrency,
       invoiceRate,
-      currency,
+      displayCurrency,
       rate
     );
-    return format(normalized, currency);
+    return format(normalized, displayCurrency);
   };
 
 


### PR DESCRIPTION
### Summary
This PR fixes incorrect currency display across the invoice list, view modal, and edit modal — ensuring USD invoices are shown in USD (not re-converted to KES) and that amounts are never double-converted.

### Problem
When invoices were created in USD, several parts of the UI were incorrectly re-converting already-stored USD amounts using the active UI exchange rate, causing:
- The invoice list to display USD amounts labeled as KSH
- The view modal to re-convert USD amounts back to KES instead of displaying them in USD
- The edit modal to apply an additional conversion on top of already-correct USD values

### Solution
Each display context now uses the invoice's own `currency_code` as the target display currency instead of the global UI currency. The `normalizeInvoiceAmount` utility is called with the invoice's currency as both source and target when the invoice currency matches its stored denomination, preventing any re-conversion.

### Key Changes
- **`src/pages/Invoices.tsx`**: `displayAmount` now resolves `displayCurrency` from the invoice's own `currency_code` rather than the global UI currency, so USD invoices render with USD formatting in the list
- **`src/components/invoices/ViewInvoiceModal.tsx`**: `formatCurrency` passes the invoice's `currency_code` as the target currency to `format()`, ensuring the view modal displays amounts in the invoice's original currency
- **`src/components/invoices/EditInvoiceModal.tsx`**: Imports and applies `normalizeInvoiceAmount` using the invoice's own currency as the display target, preventing a second conversion when opening a USD invoice for editing


---

<a href="https://builder.io/app/projects/e0581d4ab02749219bb4/frosted-reactor-asoeetdu"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://e0581d4ab02749219bb4-frosted-reactor-asoeetdu.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=e0581d4ab02749219bb4&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 68`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e0581d4ab02749219bb4</projectId>-->
<!--<branchName>frosted-reactor-asoeetdu</branchName>-->