### PR TITLE
Fix PDF downloads to use locked invoice amounts

### DIFF
--- a/src/components/remittance/ViewRemittanceModal.tsx
+++ b/src/components/remittance/ViewRemittanceModal.tsx
@@ -81,7 +81,7 @@ export function ViewRemittanceModal({
         items: remittance.items || [] // Fallback for legacy format
       };
 
-      downloadRemittancePDF(remittanceData);
+      downloadRemittancePDF(remittanceData, undefined, rate);
       toast.success(`PDF download started for ${remittance.advice_number || remittance.adviceNumber}`);
       onDownload?.();
     } catch (error) {

--- a/src/hooks/useCreditNotePDF.ts
+++ b/src/hooks/useCreditNotePDF.ts
@@ -2,9 +2,11 @@ import { useMutation } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { downloadCreditNotePDF, type CompanyDetails } from '@/utils/pdfGenerator';
 import { useCompanies } from '@/hooks/useDatabase';
+import { useCurrency } from '@/contexts/CurrencyContext';
 
 export function useCreditNotePDFDownload() {
   const { data: companies } = useCompanies();
+  const { rate } = useCurrency();
   const currentCompany = companies?.[0];
 
   return useMutation({
@@ -21,7 +23,7 @@ export function useCreditNotePDFDownload() {
       };
 
       // Generate and download PDF using shared generator
-      await downloadCreditNotePDF(creditNote, companyData);
+      await downloadCreditNotePDF(creditNote, companyData, rate);
 
       return { success: true };
     },

--- a/src/pages/DeliveryNotes.tsx
+++ b/src/pages/DeliveryNotes.tsx
@@ -131,7 +131,7 @@ export default function DeliveryNotes() {
         logo_url: currentCompany.logo_url
       } : undefined;
 
-      await downloadDeliveryNotePDF(deliveryNote, companyDetails);
+      await downloadDeliveryNotePDF(deliveryNote, companyDetails, rate);
       const noteNumber = deliveryNote.delivery_note_number || deliveryNote.delivery_number;
       toast.success(`Delivery note ${noteNumber} PDF downloaded successfully!`);
     } catch (error) {

--- a/src/pages/Invoices.tsx
+++ b/src/pages/Invoices.tsx
@@ -211,7 +211,7 @@ export default function Invoices() {
         logo_url: currentCompany.logo_url
       } : undefined;
 
-      downloadInvoicePDF(invoice, 'INVOICE', companyDetails);
+      downloadInvoicePDF(invoice, 'INVOICE', companyDetails, rate);
       toast.success(`PDF download started for ${invoice.invoice_number}`);
     } catch (error) {
       console.error('Error downloading PDF:', error);

--- a/src/pages/LPOs.tsx
+++ b/src/pages/LPOs.tsx
@@ -137,7 +137,7 @@ export default function LPOs() {
         country: currentCompany.country,
         tax_number: currentCompany.tax_number,
         logo_url: currentCompany.logo_url
-      });
+      }, rate);
 
       toast.success(`LPO ${lpo.lpo_number} PDF generated successfully!`);
     } catch (error) {

--- a/src/pages/Proforma.tsx
+++ b/src/pages/Proforma.tsx
@@ -177,7 +177,7 @@ export default function Proforma() {
         logo_url: currentCompany.logo_url
       } : undefined;
 
-      await downloadInvoicePDF(invoiceData, 'PROFORMA', companyDetails);
+      await downloadInvoicePDF(invoiceData, 'PROFORMA', companyDetails, rate);
       toast.success('Proforma PDF downloaded successfully!');
     } catch (error) {
       console.error('Error downloading PDF:', error);

--- a/src/pages/Quotations.tsx
+++ b/src/pages/Quotations.tsx
@@ -175,7 +175,7 @@ export default function Quotations() {
         logo_url: currentCompany.logo_url
       } : undefined;
 
-      downloadQuotationPDF(quotation, companyDetails);
+      downloadQuotationPDF(quotation, companyDetails, rate);
       toast.success(`PDF download started for ${quotation.quotation_number}`);
     } catch (error) {
       console.error('Error downloading PDF:', error);

--- a/src/pages/Receipts.tsx
+++ b/src/pages/Receipts.tsx
@@ -197,7 +197,7 @@ export default function Receipts() {
         logo_url: currentCompany.logo_url
       } : undefined;
 
-      downloadReceiptPDF(receipt, companyDetails);
+      downloadReceiptPDF(receipt, companyDetails, rate);
       toast.success(`PDF download started for ${receipt.invoice_number}`);
     } catch (error) {
       console.error('Error downloading PDF:', error);

--- a/src/pages/RemittanceAdvice.tsx
+++ b/src/pages/RemittanceAdvice.tsx
@@ -111,7 +111,7 @@ const RemittanceAdvice = () => {
         logo_url: currentCompany.logo_url
       } : undefined;
 
-      downloadRemittancePDF(remittanceData, companyDetails);
+      downloadRemittancePDF(remittanceData, companyDetails, rate);
       toast.success(`PDF download started for ${remittance.advice_number}`);
     } catch (error) {
       console.error('Error downloading PDF:', error);

--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -4,6 +4,7 @@ import { sanitizeAndEscape } from './textSanitizer';
 import { getLocaleForCurrency } from './exchangeRates';
 import { formatCurrency as formatCurrencyUtil } from '@/utils/formatCurrency';
 import { supabase } from '@/integrations/supabase/client';
+import { normalizeInvoiceAmount } from '@/utils/currency';
 
 // PDF Generation utility using HTML to print/PDF conversion
 // Since we don't have jsPDF installed, I'll create a simple HTML-to-print function
@@ -1529,7 +1530,7 @@ export const generatePDFDownload = async (data: DocumentData) => {
 };
 
 // Specific function for invoice PDF generation
-export const downloadInvoicePDF = async (invoice: any, documentType: 'INVOICE' | 'PROFORMA' = 'INVOICE', company?: CompanyDetails) => {
+export const downloadInvoicePDF = async (invoice: any, documentType: 'INVOICE' | 'PROFORMA' = 'INVOICE', company?: CompanyDetails, currentRate: number = 1) => {
   let invoiceItems = invoice.invoice_items;
 
   if (!invoiceItems || invoiceItems.length === 0) {
@@ -1560,6 +1561,9 @@ export const downloadInvoicePDF = async (invoice: any, documentType: 'INVOICE' |
     }
   }
 
+  const invoiceCurrencyCode = invoice.currency_code === 'USD' || invoice.currency_code === 'KES' ? invoice.currency_code : (Number(invoice.exchange_rate) && Number(invoice.exchange_rate) !== 1 ? 'USD' : 'KES');
+  const invoiceRate = Number.isFinite(invoice.exchange_rate) ? invoice.exchange_rate : currentRate;
+
   const documentData: DocumentData = {
     type: documentType === 'PROFORMA' ? 'proforma' : 'invoice',
     number: invoice.invoice_number,
@@ -1589,24 +1593,24 @@ export const downloadInvoicePDF = async (invoice: any, documentType: 'INVOICE' |
         product_name: productName,
         description,
         quantity: quantity,
-        unit_price: unitPrice,
+        unit_price: normalizeInvoiceAmount(unitPrice, invoiceCurrencyCode, invoiceRate, invoiceCurrencyCode, currentRate),
         discount_percentage: Number(item.discount_percentage || 0),
         discount_before_vat: Number(item.discount_before_vat || 0),
-        discount_amount: discountAmount,
+        discount_amount: normalizeInvoiceAmount(discountAmount, invoiceCurrencyCode, invoiceRate, invoiceCurrencyCode, currentRate),
         tax_percentage: Number(item.tax_percentage || 0),
-        tax_amount: taxAmount,
+        tax_amount: normalizeInvoiceAmount(taxAmount, invoiceCurrencyCode, invoiceRate, invoiceCurrencyCode, currentRate),
         tax_inclusive: item.tax_inclusive || false,
-        line_total: Number(item.line_total ?? computedLineTotal),
+        line_total: normalizeInvoiceAmount(Number(item.line_total ?? computedLineTotal), invoiceCurrencyCode, invoiceRate, invoiceCurrencyCode, currentRate),
         unit_of_measure: resolveLineItemUnit(item),
       };
     }) || [],
-    subtotal: invoice.subtotal,
-    tax_amount: invoice.tax_amount,
-    total_amount: invoice.total_amount,
-    paid_amount: invoice.paid_amount || 0,
-    balance_due: invoice.balance_due || (invoice.total_amount - (invoice.paid_amount || 0)),
+    subtotal: normalizeInvoiceAmount(invoice.subtotal, invoiceCurrencyCode, invoiceRate, invoiceCurrencyCode, currentRate),
+    tax_amount: normalizeInvoiceAmount(invoice.tax_amount, invoiceCurrencyCode, invoiceRate, invoiceCurrencyCode, currentRate),
+    total_amount: normalizeInvoiceAmount(invoice.total_amount, invoiceCurrencyCode, invoiceRate, invoiceCurrencyCode, currentRate),
+    paid_amount: normalizeInvoiceAmount(invoice.paid_amount || 0, invoiceCurrencyCode, invoiceRate, invoiceCurrencyCode, currentRate),
+    balance_due: normalizeInvoiceAmount(invoice.balance_due || (invoice.total_amount - (invoice.paid_amount || 0)), invoiceCurrencyCode, invoiceRate, invoiceCurrencyCode, currentRate),
     notes: invoice.notes,
-    currency_code: (invoice.currency_code === 'USD' || invoice.currency_code === 'KES' ? invoice.currency_code : (Number(invoice.exchange_rate) && Number(invoice.exchange_rate) !== 1 ? 'USD' : 'KES')),
+    currency_code: invoiceCurrencyCode,
     exchange_rate: invoice.exchange_rate,
     fx_date: invoice.fx_date,
     terms_and_conditions: (documentType === 'INVOICE' || documentType === 'PROFORMA') ? `Terms
@@ -1627,13 +1631,16 @@ Buyer shall indemnify and hold Seller harmless from and against any and all clai
 };
 
 // Function for credit note PDF generation (uses same format as quotation)
-export const downloadCreditNotePDF = async (creditNote: any, company?: CompanyDetails) => {
+export const downloadCreditNotePDF = async (creditNote: any, company?: CompanyDetails, currentRate: number = 1) => {
+  const creditNoteCurrencyCode = creditNote.currency_code === 'USD' || creditNote.currency_code === 'KES' ? creditNote.currency_code : (Number(creditNote.exchange_rate) && Number(creditNote.exchange_rate) !== 1 ? 'USD' : 'KES');
+  const creditNoteRate = Number.isFinite(creditNote.exchange_rate) ? creditNote.exchange_rate : currentRate;
+
   const documentData: DocumentData = {
     type: 'credit_note',
     number: creditNote.credit_note_number,
     date: creditNote.credit_note_date,
     company: company, // Pass company details
-    currency_code: (creditNote.currency_code === 'USD' || creditNote.currency_code === 'KES' ? creditNote.currency_code : (Number(creditNote.exchange_rate) && Number(creditNote.exchange_rate) !== 1 ? 'USD' : 'KES')),
+    currency_code: creditNoteCurrencyCode,
     customer: {
       name: creditNote.customers?.name || 'Unknown Customer',
       email: creditNote.customers?.email,
@@ -1656,19 +1663,19 @@ export const downloadCreditNotePDF = async (creditNote: any, company?: CompanyDe
         product_name: productName,
         description,
         quantity: quantity,
-        unit_price: unitPrice,
+        unit_price: normalizeInvoiceAmount(unitPrice, creditNoteCurrencyCode, creditNoteRate, creditNoteCurrencyCode, currentRate),
         discount_percentage: Number(item.discount_percentage || 0),
-        discount_amount: discountAmount,
+        discount_amount: normalizeInvoiceAmount(discountAmount, creditNoteCurrencyCode, creditNoteRate, creditNoteCurrencyCode, currentRate),
         tax_percentage: Number(item.tax_percentage || 0),
-        tax_amount: taxAmount,
+        tax_amount: normalizeInvoiceAmount(taxAmount, creditNoteCurrencyCode, creditNoteRate, creditNoteCurrencyCode, currentRate),
         tax_inclusive: item.tax_inclusive || false,
-        line_total: Number(item.line_total ?? computedLineTotal),
+        line_total: normalizeInvoiceAmount(Number(item.line_total ?? computedLineTotal), creditNoteCurrencyCode, creditNoteRate, creditNoteCurrencyCode, currentRate),
         unit_of_measure: resolveLineItemUnit(item),
       };
     }) || [],
-    subtotal: creditNote.subtotal,
-    tax_amount: creditNote.tax_amount,
-    total_amount: creditNote.total_amount,
+    subtotal: normalizeInvoiceAmount(creditNote.subtotal, creditNoteCurrencyCode, creditNoteRate, creditNoteCurrencyCode, currentRate),
+    tax_amount: normalizeInvoiceAmount(creditNote.tax_amount, creditNoteCurrencyCode, creditNoteRate, creditNoteCurrencyCode, currentRate),
+    total_amount: normalizeInvoiceAmount(creditNote.total_amount, creditNoteCurrencyCode, creditNoteRate, creditNoteCurrencyCode, currentRate),
     notes: creditNote.notes,
     terms_and_conditions: creditNote.terms_and_conditions,
   };
@@ -1677,14 +1684,17 @@ export const downloadCreditNotePDF = async (creditNote: any, company?: CompanyDe
 };
 
 // Function for quotation PDF generation
-export const downloadQuotationPDF = async (quotation: any, company?: CompanyDetails) => {
+export const downloadQuotationPDF = async (quotation: any, company?: CompanyDetails, currentRate: number = 1) => {
+  const quotationCurrencyCode = quotation.currency_code === 'USD' || quotation.currency_code === 'KES' ? quotation.currency_code : (Number(quotation.exchange_rate) && Number(quotation.exchange_rate) !== 1 ? 'USD' : 'KES');
+  const quotationRate = Number.isFinite(quotation.exchange_rate) ? quotation.exchange_rate : currentRate;
+
   const documentData: DocumentData = {
     type: 'quotation',
     number: quotation.quotation_number,
     date: quotation.quotation_date,
     valid_until: quotation.valid_until,
     company: company, // Pass company details
-    currency_code: (quotation.currency_code === 'USD' || quotation.currency_code === 'KES' ? quotation.currency_code : (Number(quotation.exchange_rate) && Number(quotation.exchange_rate) !== 1 ? 'USD' : 'KES')),
+    currency_code: quotationCurrencyCode,
     customer: {
       name: quotation.customers?.name || 'Unknown Customer',
       email: quotation.customers?.email,
@@ -1707,19 +1717,19 @@ export const downloadQuotationPDF = async (quotation: any, company?: CompanyDeta
         product_name: productName,
         description,
         quantity: quantity,
-        unit_price: unitPrice,
+        unit_price: normalizeInvoiceAmount(unitPrice, quotationCurrencyCode, quotationRate, quotationCurrencyCode, currentRate),
         discount_percentage: Number(item.discount_percentage || 0),
-        discount_amount: discountAmount,
+        discount_amount: normalizeInvoiceAmount(discountAmount, quotationCurrencyCode, quotationRate, quotationCurrencyCode, currentRate),
         tax_percentage: Number(item.tax_percentage || 0),
-        tax_amount: taxAmount,
+        tax_amount: normalizeInvoiceAmount(taxAmount, quotationCurrencyCode, quotationRate, quotationCurrencyCode, currentRate),
         tax_inclusive: item.tax_inclusive || false,
-        line_total: Number(item.line_total ?? computedLineTotal),
+        line_total: normalizeInvoiceAmount(Number(item.line_total ?? computedLineTotal), quotationCurrencyCode, quotationRate, quotationCurrencyCode, currentRate),
         unit_of_measure: resolveLineItemUnit(item),
       };
     }) || [],
-    subtotal: quotation.subtotal,
-    tax_amount: quotation.tax_amount,
-    total_amount: quotation.total_amount,
+    subtotal: normalizeInvoiceAmount(quotation.subtotal, quotationCurrencyCode, quotationRate, quotationCurrencyCode, currentRate),
+    tax_amount: normalizeInvoiceAmount(quotation.tax_amount, quotationCurrencyCode, quotationRate, quotationCurrencyCode, currentRate),
+    total_amount: normalizeInvoiceAmount(quotation.total_amount, quotationCurrencyCode, quotationRate, quotationCurrencyCode, currentRate),
     notes: quotation.notes,
     terms_and_conditions: quotation.terms_and_conditions,
   };
@@ -1917,13 +1927,16 @@ export const generatePaymentReceiptPDF = async (payment: any, company?: CompanyD
 };
 
 // Function for generating remittance advice PDF
-export const downloadRemittancePDF = async (remittance: any, company?: CompanyDetails) => {
+export const downloadRemittancePDF = async (remittance: any, company?: CompanyDetails, currentRate: number = 1) => {
+  const remittanceCurrencyCode = remittance.currency_code === 'USD' || remittance.currency_code === 'KES' ? remittance.currency_code : (Number(remittance.exchange_rate) && Number(remittance.exchange_rate) !== 1 ? 'USD' : 'KES');
+  const remittanceRate = Number.isFinite(remittance.exchange_rate) ? remittance.exchange_rate : currentRate;
+
   const documentData: DocumentData = {
     type: 'remittance',
     number: remittance.adviceNumber || remittance.advice_number || `REM-${Date.now()}`,
     date: remittance.adviceDate || remittance.advice_date || new Date().toISOString().split('T')[0],
     company: company, // Pass company details
-    currency_code: (remittance.currency_code === 'USD' || remittance.currency_code === 'KES' ? remittance.currency_code : (Number(remittance.exchange_rate) && Number(remittance.exchange_rate) !== 1 ? 'USD' : 'KES')),
+    currency_code: remittanceCurrencyCode,
     customer: {
       name: remittance.customerName || remittance.customers?.name || 'Unknown Customer',
       email: remittance.customers?.email,
@@ -1938,19 +1951,19 @@ export const downloadRemittancePDF = async (remittance: any, company?: CompanyDe
         : item.description
         || `Payment for ${item.invoiceNumber || item.creditNote || 'Document'}`,
       quantity: 1,
-      unit_price: item.payment_amount || item.payment || 0,
+      unit_price: normalizeInvoiceAmount(item.payment_amount || item.payment || 0, remittanceCurrencyCode, remittanceRate, remittanceCurrencyCode, currentRate),
       tax_percentage: item.tax_percentage || 0,
-      tax_amount: item.tax_amount || 0,
+      tax_amount: normalizeInvoiceAmount(item.tax_amount || 0, remittanceCurrencyCode, remittanceRate, remittanceCurrencyCode, currentRate),
       tax_inclusive: item.tax_inclusive || false,
-      line_total: item.payment_amount || item.payment || 0,
+      line_total: normalizeInvoiceAmount(item.payment_amount || item.payment || 0, remittanceCurrencyCode, remittanceRate, remittanceCurrencyCode, currentRate),
       // Additional details for remittance-specific display
       document_date: item.document_date || item.date,
-      invoice_amount: item.invoice_amount || item.invoiceAmount,
-      credit_amount: item.credit_amount || item.creditAmount,
+      invoice_amount: normalizeInvoiceAmount(item.invoice_amount || item.invoiceAmount, remittanceCurrencyCode, remittanceRate, remittanceCurrencyCode, currentRate),
+      credit_amount: normalizeInvoiceAmount(item.credit_amount || item.creditAmount, remittanceCurrencyCode, remittanceRate, remittanceCurrencyCode, currentRate),
     })),
-    subtotal: remittance.totalPayment || remittance.total_payment || 0,
+    subtotal: normalizeInvoiceAmount(remittance.totalPayment || remittance.total_payment || 0, remittanceCurrencyCode, remittanceRate, remittanceCurrencyCode, currentRate),
     tax_amount: 0,
-    total_amount: remittance.totalPayment || remittance.total_payment || 0,
+    total_amount: normalizeInvoiceAmount(remittance.totalPayment || remittance.total_payment || 0, remittanceCurrencyCode, remittanceRate, remittanceCurrencyCode, currentRate),
     notes: remittance.notes || 'Remittance advice for payments made',
     terms_and_conditions: 'This remittance advice details payments made to your account.',
   };
@@ -1959,11 +1972,13 @@ export const downloadRemittancePDF = async (remittance: any, company?: CompanyDe
 };
 
 // Function for delivery note PDF generation
-export const downloadDeliveryNotePDF = async (deliveryNote: any, company?: CompanyDetails) => {
+export const downloadDeliveryNotePDF = async (deliveryNote: any, company?: CompanyDetails, currentRate: number = 1) => {
   // Get invoice information for reference
   const invoiceNumber = deliveryNote.invoice_number ||
                        deliveryNote.invoices?.invoice_number ||
                        (deliveryNote.invoice_id ? `INV-${deliveryNote.invoice_id.slice(-8)}` : 'N/A');
+
+  const deliveryNoteCurrencyCode = deliveryNote.currency_code === 'USD' || deliveryNote.currency_code === 'KES' ? deliveryNote.currency_code : (Number(deliveryNote.exchange_rate) && Number(deliveryNote.exchange_rate) !== 1 ? 'USD' : 'KES');
 
   const documentData: DocumentData = {
     type: 'delivery',
@@ -1979,7 +1994,7 @@ export const downloadDeliveryNotePDF = async (deliveryNote: any, company?: Compa
     // Add invoice reference for delivery notes
     lpo_number: `Related Invoice: ${invoiceNumber}`,
     company: company, // Pass company details
-    currency_code: (deliveryNote.currency_code === 'USD' || deliveryNote.currency_code === 'KES' ? deliveryNote.currency_code : (Number(deliveryNote.exchange_rate) && Number(deliveryNote.exchange_rate) !== 1 ? 'USD' : 'KES')),
+    currency_code: deliveryNoteCurrencyCode,
     customer: {
       name: deliveryNote.customers?.name || 'Unknown Customer',
       email: deliveryNote.customers?.email,
@@ -2013,7 +2028,7 @@ export const downloadDeliveryNotePDF = async (deliveryNote: any, company?: Compa
 };
 
 // Function for LPO PDF generation
-export const downloadLPOPDF = async (lpo: any, company?: CompanyDetails) => {
+export const downloadLPOPDF = async (lpo: any, company?: CompanyDetails, currentRate: number = 1) => {
   const documentData: DocumentData = {
     type: 'lpo', // Use LPO document type
     number: lpo.lpo_number,
@@ -2032,6 +2047,8 @@ export const downloadLPOPDF = async (lpo: any, company?: CompanyDetails) => {
       country: lpo.suppliers?.country,
     },
     items: lpo.lpo_items?.map((item: any) => {
+      const lpoCurrencyCode = lpo.currency_code === 'USD' || lpo.currency_code === 'KES' ? lpo.currency_code : (Number(lpo.exchange_rate) && Number(lpo.exchange_rate) !== 1 ? 'USD' : 'KES');
+      const lpoRate = Number.isFinite(lpo.exchange_rate) ? lpo.exchange_rate : currentRate;
       const quantity = Number(item.quantity || 0);
       const unitPrice = Number(item.unit_price || 0);
       const taxAmount = Number(item.tax_amount || 0);
@@ -2040,19 +2057,31 @@ export const downloadLPOPDF = async (lpo: any, company?: CompanyDetails) => {
       return {
         description: item.description || item.products?.name || 'Unknown Item',
         quantity: quantity,
-        unit_price: unitPrice,
+        unit_price: normalizeInvoiceAmount(unitPrice, lpoCurrencyCode, lpoRate, lpoCurrencyCode, currentRate),
         discount_percentage: 0,
         discount_amount: 0,
         tax_percentage: Number(item.tax_rate || 0),
-        tax_amount: taxAmount,
+        tax_amount: normalizeInvoiceAmount(taxAmount, lpoCurrencyCode, lpoRate, lpoCurrencyCode, currentRate),
         tax_inclusive: false,
-        line_total: Number(item.line_total ?? computedLineTotal),
+        line_total: normalizeInvoiceAmount(Number(item.line_total ?? computedLineTotal), lpoCurrencyCode, lpoRate, lpoCurrencyCode, currentRate),
         unit_of_measure: item.products?.unit_of_measure || 'pcs',
       };
     }) || [],
-    subtotal: lpo.subtotal,
-    tax_amount: lpo.tax_amount,
-    total_amount: lpo.total_amount,
+    subtotal: ((): number => {
+      const lpoCurrencyCode = lpo.currency_code === 'USD' || lpo.currency_code === 'KES' ? lpo.currency_code : (Number(lpo.exchange_rate) && Number(lpo.exchange_rate) !== 1 ? 'USD' : 'KES');
+      const lpoRate = Number.isFinite(lpo.exchange_rate) ? lpo.exchange_rate : currentRate;
+      return normalizeInvoiceAmount(lpo.subtotal, lpoCurrencyCode, lpoRate, lpoCurrencyCode, currentRate);
+    })(),
+    tax_amount: ((): number => {
+      const lpoCurrencyCode = lpo.currency_code === 'USD' || lpo.currency_code === 'KES' ? lpo.currency_code : (Number(lpo.exchange_rate) && Number(lpo.exchange_rate) !== 1 ? 'USD' : 'KES');
+      const lpoRate = Number.isFinite(lpo.exchange_rate) ? lpo.exchange_rate : currentRate;
+      return normalizeInvoiceAmount(lpo.tax_amount, lpoCurrencyCode, lpoRate, lpoCurrencyCode, currentRate);
+    })(),
+    total_amount: ((): number => {
+      const lpoCurrencyCode = lpo.currency_code === 'USD' || lpo.currency_code === 'KES' ? lpo.currency_code : (Number(lpo.exchange_rate) && Number(lpo.exchange_rate) !== 1 ? 'USD' : 'KES');
+      const lpoRate = Number.isFinite(lpo.exchange_rate) ? lpo.exchange_rate : currentRate;
+      return normalizeInvoiceAmount(lpo.total_amount, lpoCurrencyCode, lpoRate, lpoCurrencyCode, currentRate);
+    })(),
     notes: `${lpo.notes || ''}${lpo.contact_person ? `\n\nContact Person: ${lpo.contact_person}` : ''}${lpo.contact_phone ? `\nContact Phone: ${lpo.contact_phone}` : ''}`.trim(),
     terms_and_conditions: lpo.terms_and_conditions,
   };
@@ -2061,7 +2090,7 @@ export const downloadLPOPDF = async (lpo: any, company?: CompanyDetails) => {
 };
 
 // Function for receipt PDF generation (like invoice but no terms page, just thank you note)
-export const downloadReceiptPDF = async (receipt: any, company?: CompanyDetails) => {
+export const downloadReceiptPDF = async (receipt: any, company?: CompanyDetails, currentRate: number = 1) => {
   const documentData: DocumentData = {
     type: 'receipt',
     number: receipt.invoice_number,
@@ -2075,36 +2104,60 @@ export const downloadReceiptPDF = async (receipt: any, company?: CompanyDetails)
       city: receipt.customers?.city,
       country: receipt.customers?.country,
     },
-    items: receipt.invoice_items?.map((item: any, index: number) => {
-      const quantity = Number(item.quantity || 0);
-      const unitPrice = Number(item.unit_price || 0);
-      const taxAmount = Number(item.tax_amount || 0);
-      const discountAmount = Number(item.discount_amount || 0);
-      const computedLineTotal = quantity * unitPrice - discountAmount + taxAmount;
-      const productName = toTrimmedString(item?.products?.name) || toTrimmedString(item?.product_name) || `Item ${index + 1}`;
-      const description = toTrimmedString(item?.products?.description) || toTrimmedString(item?.description) || '';
+    items: (() => {
+      const receiptCurrencyCode = receipt.currency_code === 'USD' || receipt.currency_code === 'KES' ? receipt.currency_code : (Number(receipt.exchange_rate) && Number(receipt.exchange_rate) !== 1 ? 'USD' : 'KES');
+      const receiptRate = Number.isFinite(receipt.exchange_rate) ? receipt.exchange_rate : currentRate;
+      return receipt.invoice_items?.map((item: any, index: number) => {
+        const quantity = Number(item.quantity || 0);
+        const unitPrice = Number(item.unit_price || 0);
+        const taxAmount = Number(item.tax_amount || 0);
+        const discountAmount = Number(item.discount_amount || 0);
+        const computedLineTotal = quantity * unitPrice - discountAmount + taxAmount;
+        const productName = toTrimmedString(item?.products?.name) || toTrimmedString(item?.product_name) || `Item ${index + 1}`;
+        const description = toTrimmedString(item?.products?.description) || toTrimmedString(item?.description) || '';
 
-      return {
-        product_code: resolveLineItemCode(item),
-        product_name: productName,
-        description,
-        quantity: quantity,
-        unit_price: unitPrice,
-        discount_percentage: Number(item.discount_percentage || 0),
-        discount_before_vat: Number(item.discount_before_vat || 0),
-        discount_amount: discountAmount,
-        tax_percentage: Number(item.tax_percentage || 0),
-        tax_amount: taxAmount,
-        tax_inclusive: item.tax_inclusive || false,
-        line_total: Number(item.line_total ?? computedLineTotal),
-        unit_of_measure: resolveLineItemUnit(item),
-      };
-    }) || [],
-    subtotal: receipt.subtotal,
-    tax_amount: receipt.tax_amount,
-    total_amount: receipt.total_amount,
-    paid_amount: receipt.paid_amount || receipt.total_amount || 0,
-    balance_due: receipt.balance_due !== undefined ? receipt.balance_due : 0,
+        return {
+          product_code: resolveLineItemCode(item),
+          product_name: productName,
+          description,
+          quantity: quantity,
+          unit_price: normalizeInvoiceAmount(unitPrice, receiptCurrencyCode, receiptRate, receiptCurrencyCode, currentRate),
+          discount_percentage: Number(item.discount_percentage || 0),
+          discount_before_vat: Number(item.discount_before_vat || 0),
+          discount_amount: normalizeInvoiceAmount(discountAmount, receiptCurrencyCode, receiptRate, receiptCurrencyCode, currentRate),
+          tax_percentage: Number(item.tax_percentage || 0),
+          tax_amount: normalizeInvoiceAmount(taxAmount, receiptCurrencyCode, receiptRate, receiptCurrencyCode, currentRate),
+          tax_inclusive: item.tax_inclusive || false,
+          line_total: normalizeInvoiceAmount(Number(item.line_total ?? computedLineTotal), receiptCurrencyCode, receiptRate, receiptCurrencyCode, currentRate),
+          unit_of_measure: resolveLineItemUnit(item),
+        };
+      }) || [];
+    })(),
+    subtotal: (() => {
+      const receiptCurrencyCode = receipt.currency_code === 'USD' || receipt.currency_code === 'KES' ? receipt.currency_code : (Number(receipt.exchange_rate) && Number(receipt.exchange_rate) !== 1 ? 'USD' : 'KES');
+      const receiptRate = Number.isFinite(receipt.exchange_rate) ? receipt.exchange_rate : currentRate;
+      return normalizeInvoiceAmount(receipt.subtotal, receiptCurrencyCode, receiptRate, receiptCurrencyCode, currentRate);
+    })(),
+    tax_amount: (() => {
+      const receiptCurrencyCode = receipt.currency_code === 'USD' || receipt.currency_code === 'KES' ? receipt.currency_code : (Number(receipt.exchange_rate) && Number(receipt.exchange_rate) !== 1 ? 'USD' : 'KES');
+      const receiptRate = Number.isFinite(receipt.exchange_rate) ? receipt.exchange_rate : currentRate;
+      return normalizeInvoiceAmount(receipt.tax_amount, receiptCurrencyCode, receiptRate, receiptCurrencyCode, currentRate);
+    })(),
+    total_amount: (() => {
+      const receiptCurrencyCode = receipt.currency_code === 'USD' || receipt.currency_code === 'KES' ? receipt.currency_code : (Number(receipt.exchange_rate) && Number(receipt.exchange_rate) !== 1 ? 'USD' : 'KES');
+      const receiptRate = Number.isFinite(receipt.exchange_rate) ? receipt.exchange_rate : currentRate;
+      return normalizeInvoiceAmount(receipt.total_amount, receiptCurrencyCode, receiptRate, receiptCurrencyCode, currentRate);
+    })(),
+    paid_amount: (() => {
+      const receiptCurrencyCode = receipt.currency_code === 'USD' || receipt.currency_code === 'KES' ? receipt.currency_code : (Number(receipt.exchange_rate) && Number(receipt.exchange_rate) !== 1 ? 'USD' : 'KES');
+      const receiptRate = Number.isFinite(receipt.exchange_rate) ? receipt.exchange_rate : currentRate;
+      return normalizeInvoiceAmount(receipt.paid_amount || receipt.total_amount || 0, receiptCurrencyCode, receiptRate, receiptCurrencyCode, currentRate);
+    })(),
+    balance_due: (() => {
+      const receiptCurrencyCode = receipt.currency_code === 'USD' || receipt.currency_code === 'KES' ? receipt.currency_code : (Number(receipt.exchange_rate) && Number(receipt.exchange_rate) !== 1 ? 'USD' : 'KES');
+      const receiptRate = Number.isFinite(receipt.exchange_rate) ? receipt.exchange_rate : currentRate;
+      return receipt.balance_due !== undefined ? normalizeInvoiceAmount(receipt.balance_due, receiptCurrencyCode, receiptRate, receiptCurrencyCode, currentRate) : 0;
+    })(),
     notes: receipt.notes,
     currency_code: (receipt.currency_code === 'USD' || receipt.currency_code === 'KES' ? receipt.currency_code : (Number(receipt.exchange_rate) && Number(receipt.exchange_rate) !== 1 ? 'USD' : 'KES')),
     terms_and_conditions: 'Thank you for your purchase. This is a sales receipt confirming payment has been received.',


### PR DESCRIPTION
### Summary
This PR fixes PDF generation across all document types (invoices, proformas, receipts, LPOs, quotations, delivery notes, credit notes, and remittance advice) to use the invoice's stored/locked amounts instead of recalculating them using the current exchange rate.

### Problem
PDF downloads were not respecting the exchange rate locked at the time a document was created. For example, USD invoices would have their amounts recalculated using the current live rate rather than displaying the original stored values, causing incorrect figures in downloaded PDFs.

### Solution
The `currentRate` (from `CurrencyContext`) is now passed through to all PDF generator functions. Inside each generator, `normalizeInvoiceAmount` is used with the document's own stored exchange rate and currency code, ensuring amounts are rendered in the document's original currency without re-conversion.

### Key Changes
- **`pdfGenerator.ts`**: Updated `downloadInvoicePDF`, `downloadReceiptPDF`, and `downloadLPOPDF` to accept a `currentRate` parameter and apply `normalizeInvoiceAmount` to all monetary fields (unit price, discount, tax, line total, subtotal, tax amount, total, paid amount, balance due)
- **`Invoices.tsx`, `Proforma.tsx`, `Quotations.tsx`, `Receipts.tsx`, `LPOs.tsx`, `DeliveryNotes.tsx`, `RemittanceAdvice.tsx`**: Pass the current `rate` from `useCurrency` into their respective PDF download calls
- **`useCreditNotePDF.ts`**: Integrated `useCurrency` hook and passes `rate` to `downloadCreditNotePDF`
- **`ViewRemittanceModal.tsx`**: Passes the locked `rate` when calling `downloadRemittancePDF`
- Imported `normalizeInvoiceAmount` utility into `pdfGenerator.ts` to handle currency-aware amount normalization consistently


---

<a href="https://builder.io/app/projects/00fbfc46f59a4d9c9a07/mage-ball-apnn349y"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://00fbfc46f59a4d9c9a07-mage-ball-apnn349y.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=00fbfc46f59a4d9c9a07&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 69`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>00fbfc46f59a4d9c9a07</projectId>-->
<!--<branchName>mage-ball-apnn349y</branchName>-->