### PR TITLE
Default VAT to 0% exclusive in invoices and quotations

### DIFF
--- a/src/components/invoices/EditInvoiceModal.tsx
+++ b/src/components/invoices/EditInvoiceModal.tsx
@@ -322,27 +322,8 @@ export function EditInvoiceModal({ open, onOpenChange, onSuccess, invoice }: Edi
   const updateItemTaxInclusive = (itemId: string, taxInclusive: boolean) => {
     setItems(items.map(item => {
       if (item.id === itemId) {
-        // When checking VAT Inclusive, auto-apply default tax rate if no VAT is set
-        let newTaxPercentage = item.tax_percentage;
-        if (taxInclusive && item.tax_percentage === 0) {
-          newTaxPercentage = defaultTaxRate;
-        }
-        // When unchecking VAT Inclusive, reset VAT to 0
-        if (!taxInclusive) {
-          newTaxPercentage = 0;
-        }
-
-        const { lineTotal, taxAmount } = calculateLineTotal(item, undefined, undefined, undefined, newTaxPercentage, taxInclusive);
-        console.log(`VAT Inclusive changed for item ${itemId}:`, {
-          taxInclusive,
-          quantity: item.quantity,
-          unitPrice: item.unit_price,
-          oldTaxPercentage: item.tax_percentage,
-          newTaxPercentage,
-          oldLineTotal: item.line_total,
-          newLineTotal: lineTotal
-        });
-        return { ...item, tax_inclusive: taxInclusive, tax_percentage: newTaxPercentage, line_total: lineTotal, tax_amount: taxAmount };
+        const { lineTotal, taxAmount } = calculateLineTotal(item, undefined, undefined, undefined, item.tax_percentage, taxInclusive);
+        return { ...item, tax_inclusive: taxInclusive, line_total: lineTotal, tax_amount: taxAmount };
       }
       return item;
     }));

--- a/src/components/invoices/EditInvoiceModal.tsx
+++ b/src/components/invoices/EditInvoiceModal.tsx
@@ -189,7 +189,7 @@ export function EditInvoiceModal({ open, onOpenChange, onSuccess, invoice }: Edi
           unit_price: item.unit_price || 0,
           discount_percentage: item.discount_percentage || 0,
           discount_before_vat: item.discount_before_vat || 0,
-          tax_percentage: item.tax_percentage || 16,
+          tax_percentage: item.tax_percentage || 0,
           tax_amount: item.tax_amount || 0,
           tax_inclusive: item.tax_inclusive || false,
           line_total: item.line_total || 0,

--- a/src/components/quotations/EditQuotationModal.tsx
+++ b/src/components/quotations/EditQuotationModal.tsx
@@ -271,18 +271,8 @@ export function EditQuotationModal({ open, onOpenChange, onSuccess, quotation }:
   const updateItemVATInclusive = (itemId: string, vatInclusive: boolean) => {
     setItems(items.map(item => {
       if (item.id === itemId) {
-        // When checking VAT Inclusive, auto-apply default tax rate if no VAT is set
-        let newVatPercentage = item.tax_percentage;
-        if (vatInclusive && item.tax_percentage === 0) {
-          newVatPercentage = defaultTaxRate;
-        }
-        // When unchecking VAT Inclusive, reset VAT to 0
-        if (!vatInclusive) {
-          newVatPercentage = 0;
-        }
-
-        const { lineTotal, taxAmount } = calculateLineTotal(item, undefined, undefined, undefined, newVatPercentage, vatInclusive);
-        return { ...item, tax_inclusive: vatInclusive, tax_percentage: newVatPercentage, line_total: lineTotal, tax_amount: taxAmount };
+        const { lineTotal, taxAmount } = calculateLineTotal(item, undefined, undefined, undefined, item.tax_percentage, vatInclusive);
+        return { ...item, tax_inclusive: vatInclusive, line_total: lineTotal, tax_amount: taxAmount };
       }
       return item;
     }));

--- a/src/components/quotations/EditQuotationModal.tsx
+++ b/src/components/quotations/EditQuotationModal.tsx
@@ -162,7 +162,7 @@ export function EditQuotationModal({ open, onOpenChange, onSuccess, quotation }:
         quantity: item.quantity || 0,
         unit_price: item.unit_price || 0,
         discount_percentage: item.discount_percentage || 0,
-        tax_percentage: item.tax_percentage || 16,
+        tax_percentage: item.tax_percentage || 0,
         tax_amount: item.tax_amount || 0,
         tax_inclusive: item.tax_inclusive || false,
         line_total: item.line_total || 0,


### PR DESCRIPTION
### Summary
This PR updates the default VAT/tax percentage for line items in both the invoice and quotation edit modals from 16% to 0%, and simplifies the VAT inclusive toggle logic by removing auto-apply and auto-reset behaviour.

### Problem
When editing an invoice or quotation, new line items were defaulting to a 16% tax rate. The expected behaviour was for VAT to default to 0% (exclusive), requiring users to explicitly set a tax rate rather than having one applied automatically.

Additionally, toggling the "VAT Inclusive" checkbox was automatically applying a default tax rate when checked and resetting it to 0 when unchecked, which was unexpected and overly opinionated behaviour.

### Solution
- Changed the fallback `tax_percentage` from `16` to `0` in both `EditInvoiceModal` and `EditQuotationModal`.
- Removed the auto-apply and auto-reset logic from the VAT inclusive toggle handlers, so toggling inclusive/exclusive no longer modifies the tax percentage — it only recalculates the line total and tax amount using the existing rate.

### Key Changes
- **`EditInvoiceModal.tsx`**: Default `tax_percentage` fallback changed from `16` to `0`; `updateItemTaxInclusive` simplified to preserve the existing tax percentage when toggling inclusivity, and debug `console.log` removed.
- **`EditQuotationModal.tsx`**: Default `tax_percentage` fallback changed from `16` to `0`; `updateItemVATInclusive` simplified to preserve the existing tax percentage when toggling inclusivity.


---

<a href="https://builder.io/app/projects/115d3aeeca4944428f11/twisted-alley-vosanrnh"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://115d3aeeca4944428f11-twisted-alley-vosanrnh.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=115d3aeeca4944428f11&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 71`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>115d3aeeca4944428f11</projectId>-->
<!--<branchName>twisted-alley-vosanrnh</branchName>-->