### PR TITLE
Remove required description validation on quotation items

### DIFF
--- a/src/components/quotations/CreateQuotationModal.tsx
+++ b/src/components/quotations/CreateQuotationModal.tsx
@@ -432,9 +432,6 @@ export function CreateQuotationModal({ open, onOpenChange, onSuccess }: CreateQu
 
       const quotationItems = itemsToSubmit.map(item => {
         // Validate item data
-        if (!item.description || item.description.trim() === '') {
-          throw new Error(`Item "${item.product_name}" is missing a description`);
-        }
         if (item.quantity <= 0) {
           throw new Error(`Item "${item.product_name}" must have a quantity greater than 0`);
         }


### PR DESCRIPTION
### Summary
Removes the validation that threw an error when a quotation item had no description, allowing items to be saved with an empty description field.

### Problem
Quotation PDFs were showing identical text in both the "PRODUCT NAME" and "PRODUCT DESCRIPTION" columns because the description field fell back to the product name when no catalog description existed. To fix this duplication, description is intentionally left empty when a product has no catalog description — but the existing validation blocked saving any item with an empty description, preventing this correct behavior.

### Solution
Remove the guard that threw an error for missing item descriptions, so that quotation items with no description can be created without issue.

### Key Changes
- **`CreateQuotationModal.tsx`**: Removed the validation block that raised an error when `item.description` was empty or whitespace, allowing quotation items to be submitted with an empty description field.


---

<a href="https://builder.io/app/projects/a7ccee11a0084bf28979/quantum-section-wjyfrppc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://a7ccee11a0084bf28979-quantum-section-wjyfrppc.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=a7ccee11a0084bf28979&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 73`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a7ccee11a0084bf28979</projectId>-->
<!--<branchName>quantum-section-wjyfrppc</branchName>-->