### PR TITLE
Fix duplicate text in quotation and invoice PDFs

### DIFF
--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -105,7 +105,6 @@ const resolveLineItemName = (item: any, index: number): string => {
   const candidates = [
     toTrimmedString(item?.product_name),
     toTrimmedString(item?.products?.name),
-    toTrimmedString(item?.description),
     toTrimmedString(item?.product_code ?? item?.products?.product_code),
   ];
 
@@ -129,9 +128,8 @@ const resolveLineItemDescription = (item: any, fallbackName: string): string => 
   if (productDescription) {
     return productDescription;
   }
-  // Finally, fall back to a meaningful identifier like product code, or the product name
-  const code = toTrimmedString(item?.products?.product_code ?? item?.product_code);
-  return code || toTrimmedString(fallbackName) || '';
+  // Finally, fall back to product code only (never product name)
+  return toTrimmedString(item?.products?.product_code ?? item?.product_code) || '';
 };
 
 const resolveLineItemUnit = (item: any): string => {

--- a/supabase/migrations/20260629_populate_invoice_items_product_name.sql
+++ b/supabase/migrations/20260629_populate_invoice_items_product_name.sql
@@ -1,0 +1,6 @@
+-- Populate missing product_name in invoice_items from products table
+UPDATE invoice_items
+SET product_name = p.name
+FROM products p
+WHERE invoice_items.product_id = p.id
+  AND (invoice_items.product_name IS NULL OR TRIM(invoice_items.product_name) = '');

--- a/supabase/migrations/20260629_populate_quotation_items_product_name.sql
+++ b/supabase/migrations/20260629_populate_quotation_items_product_name.sql
@@ -1,0 +1,6 @@
+-- Populate missing product_name in quotation_items from products table
+UPDATE quotation_items
+SET product_name = p.name
+FROM products p
+WHERE quotation_items.product_id = p.id
+  AND (quotation_items.product_name IS NULL OR TRIM(quotation_items.product_name) = '');


### PR DESCRIPTION
### Summary
Fixes an issue where product names were appearing duplicated in quotation and invoice PDFs by correcting the line item name/description resolution logic and backfilling missing `product_name` data in the database.

### Problem
In generated PDFs for quotations and invoices, the same product name was being rendered twice — once in the name field and again in the description field. This happened because `description` was used as a fallback for the product name, and the product name itself was used as a final fallback for the description, causing the same text to appear in both columns.

### Solution
Removed `description` as a candidate for resolving the line item name, and removed the product name fallback from the description resolver. The description now falls back only to the product code (never the product name). Additionally, two migrations backfill any missing `product_name` values in `invoice_items` and `quotation_items` from the `products` table to ensure the name field is always populated correctly.

### Key Changes
- **`pdfGenerator.ts`**: Removed `item.description` from the `resolveLineItemName` candidate list to prevent description text from leaking into the name field.
- **`pdfGenerator.ts`**: Updated `resolveLineItemDescription` to fall back only to the product code, never the product name, eliminating duplicate text in PDFs.
- **`20260629_populate_invoice_items_product_name.sql`**: Migration to backfill `product_name` in `invoice_items` from the linked `products` table where it is null or empty.
- **`20260629_populate_quotation_items_product_name.sql`**: Migration to backfill `product_name` in `quotation_items` from the linked `products` table where it is null or empty.


---

<a href="https://builder.io/app/projects/932170f2bc7b4331a4ab/flash-segment-yqux5uqb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://932170f2bc7b4331a4ab-flash-segment-yqux5uqb.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=932170f2bc7b4331a4ab&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 74`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>932170f2bc7b4331a4ab</projectId>-->
<!--<branchName>flash-segment-yqux5uqb</branchName>-->