### PR TITLE
Add PDF debug logging and backfill item descriptions

### DIFF
--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -114,6 +114,16 @@ const resolveLineItemName = (item: any, index: number): string => {
     }
   }
 
+  // Debug: Log if we're falling back to Item N
+  if (item?.product_id) {
+    console.warn(`[PDF] Item ${index + 1}: No product name found for product_id ${item.product_id}`, {
+      product_name: item?.product_name,
+      products_name: item?.products?.name,
+      product_code: item?.product_code,
+      products_product_code: item?.products?.product_code
+    });
+  }
+
   return `Item ${index + 1}`;
 };
 
@@ -1687,8 +1697,15 @@ export const downloadCreditNotePDF = async (creditNote: any, company?: CompanyDe
 export const downloadQuotationPDF = async (quotation: any, company?: CompanyDetails, currentRate: number = 1) => {
   let quotationItems = quotation.quotation_items;
 
+  console.log(`[PDF] downloadQuotationPDF called for quotation ${quotation.quotation_number}`, {
+    hasQuotationItems: !!quotationItems,
+    itemCount: quotationItems?.length || 0,
+    firstItem: quotationItems?.[0]
+  });
+
   if (!quotationItems || quotationItems.length === 0) {
     try {
+      console.log(`[PDF] Fetching quotation items from database for ${quotation.id}`);
       const { data, error } = await supabase
         .from('quotation_items')
         .select(`
@@ -1710,11 +1727,24 @@ export const downloadQuotationPDF = async (quotation: any, company?: CompanyDeta
         .eq('quotation_id', quotation.id);
 
       if (!error && data) {
+        console.log(`[PDF] Fetched ${data.length} quotation items from database`);
         quotationItems = data;
+      } else {
+        console.error(`[PDF] Error fetching quotation items:`, error);
       }
     } catch (err) {
       console.error('Error fetching quotation items:', err);
     }
+  } else {
+    console.log(`[PDF] Using quotation_items from quotation object:`, {
+      itemCount: quotationItems.length,
+      items: quotationItems.map((item: any, idx: number) => ({
+        index: idx,
+        product_name: item.product_name,
+        has_products_relationship: !!item.products,
+        products_name: item.products?.name
+      }))
+    });
   }
 
   const quotationCurrencyCode = quotation.currency_code === 'USD' || quotation.currency_code === 'KES' ? quotation.currency_code : (Number(quotation.exchange_rate) && Number(quotation.exchange_rate) !== 1 ? 'USD' : 'KES');

--- a/supabase/migrations/00_diagnostic_missing_descriptions.sql
+++ b/supabase/migrations/00_diagnostic_missing_descriptions.sql
@@ -1,0 +1,60 @@
+-- Diagnostic queries to identify missing descriptions in invoice_items and quotation_items
+-- Run these to understand the gap before creating the backfill migration
+
+-- Check invoice_items: count how many have missing descriptions
+SELECT 
+  COUNT(*) as total_invoice_items,
+  COUNT(CASE WHEN (description IS NULL OR TRIM(description) = '') THEN 1 END) as missing_description,
+  COUNT(CASE WHEN (description IS NOT NULL AND TRIM(description) != '') THEN 1 END) as has_description
+FROM invoice_items;
+
+-- Check quotation_items: count how many have missing descriptions
+SELECT 
+  COUNT(*) as total_quotation_items,
+  COUNT(CASE WHEN (description IS NULL OR TRIM(description) = '') THEN 1 END) as missing_description,
+  COUNT(CASE WHEN (description IS NOT NULL AND TRIM(description) != '') THEN 1 END) as has_description
+FROM quotation_items;
+
+-- Check how many items with missing description have a product_id that could be backfilled
+SELECT 
+  'invoice_items' as type,
+  COUNT(*) as items_with_missing_description,
+  COUNT(CASE WHEN product_id IS NOT NULL THEN 1 END) as with_product_id,
+  COUNT(CASE WHEN product_id IS NOT NULL AND p.description IS NOT NULL AND TRIM(p.description) != '' THEN 1 END) as can_be_backfilled
+FROM invoice_items ii
+LEFT JOIN products p ON ii.product_id = p.id
+WHERE ii.description IS NULL OR TRIM(ii.description) = '';
+
+-- Check quotation_items for backfill potential
+SELECT 
+  'quotation_items' as type,
+  COUNT(*) as items_with_missing_description,
+  COUNT(CASE WHEN product_id IS NOT NULL THEN 1 END) as with_product_id,
+  COUNT(CASE WHEN product_id IS NOT NULL AND p.description IS NOT NULL AND TRIM(p.description) != '' THEN 1 END) as can_be_backfilled
+FROM quotation_items qi
+LEFT JOIN products p ON qi.product_id = p.id
+WHERE qi.description IS NULL OR TRIM(qi.description) = '';
+
+-- Show sample invoice_items with missing descriptions and their corresponding product data
+SELECT 
+  ii.id,
+  ii.product_name,
+  ii.description as item_description,
+  p.name as product_table_name,
+  p.description as product_table_description
+FROM invoice_items ii
+LEFT JOIN products p ON ii.product_id = p.id
+WHERE ii.description IS NULL OR TRIM(ii.description) = ''
+LIMIT 10;
+
+-- Show sample quotation_items with missing descriptions and their corresponding product data
+SELECT 
+  qi.id,
+  qi.product_name,
+  qi.description as item_description,
+  p.name as product_table_name,
+  p.description as product_table_description
+FROM quotation_items qi
+LEFT JOIN products p ON qi.product_id = p.id
+WHERE qi.description IS NULL OR TRIM(qi.description) = ''
+LIMIT 10;

--- a/supabase/migrations/20260629_backfill_missing_item_descriptions.sql
+++ b/supabase/migrations/20260629_backfill_missing_item_descriptions.sql
@@ -1,0 +1,20 @@
+-- Backfill missing descriptions in invoice_items and quotation_items from products table
+-- This ensures complete product information is displayed in generated PDFs
+
+-- Backfill invoice_items descriptions
+UPDATE invoice_items
+SET description = p.description
+FROM products p
+WHERE invoice_items.product_id = p.id
+  AND (invoice_items.description IS NULL OR TRIM(invoice_items.description) = '')
+  AND p.description IS NOT NULL
+  AND TRIM(p.description) != '';
+
+-- Backfill quotation_items descriptions
+UPDATE quotation_items
+SET description = p.description
+FROM products p
+WHERE quotation_items.product_id = p.id
+  AND (quotation_items.description IS NULL OR TRIM(quotation_items.description) = '')
+  AND p.description IS NOT NULL
+  AND TRIM(p.description) != '';


### PR DESCRIPTION
### Summary
Adds diagnostic logging to the PDF generator to trace missing product names, and introduces SQL migrations to backfill missing descriptions in `invoice_items` and `quotation_items` from the `products` table.

### Problem
Product names were appearing in quotation and invoice PDFs as "Item N" (a fallback label) instead of the actual product name. Additionally, some line items had empty descriptions in the database even though the linked product record had a valid description, causing incomplete information to appear in generated PDFs.

### Solution
Added detailed `console.warn`/`console.log` statements throughout the PDF generation flow to surface exactly where product name resolution fails. Separately, created SQL migrations to backfill missing `description` values in `invoice_items` and `quotation_items` by copying them from the associated `products` table record.

### Key Changes
- **`src/utils/pdfGenerator.ts`**: Added `console.warn` in `resolveLineItemName` when a product has a `product_id` but no resolvable name, logging all candidate fields for diagnosis. Added structured `console.log` calls in `downloadQuotationPDF` to trace whether items come from the quotation object or are fetched from the database, and to log each item's `product_name` and `products` relationship.
- **`supabase/migrations/00_diagnostic_missing_descriptions.sql`**: New diagnostic SQL file with queries to count and sample `invoice_items` and `quotation_items` with missing descriptions, and to assess backfill potential from the `products` table.
- **`supabase/migrations/20260629_backfill_missing_item_descriptions.sql`**: New migration that updates `invoice_items` and `quotation_items`, setting `description` from the linked `products` record wherever the item description is null or empty and the product has a non-empty description.

---

<a href="https://builder.io/app/projects/32ce24c77f424efda5fc/solo-watt-8reurib3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://32ce24c77f424efda5fc-solo-watt-8reurib3.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=32ce24c77f424efda5fc&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 75`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>32ce24c77f424efda5fc</projectId>-->
<!--<branchName>solo-watt-8reurib3</branchName>-->