### PR TITLE
Fix missing product name in quotation and invoice items

### DIFF
--- a/src/hooks/useOptimizedInvoices.ts
+++ b/src/hooks/useOptimizedInvoices.ts
@@ -217,6 +217,7 @@ export const useOptimizedInvoices = (
           id,
           invoice_id,
           product_id,
+          product_name,
           description,
           quantity,
           unit_price,

--- a/src/hooks/useOptimizedQuotations.ts
+++ b/src/hooks/useOptimizedQuotations.ts
@@ -31,6 +31,7 @@ export interface OptimizedQuotation {
     id: string;
     quotation_id: string;
     product_id?: string;
+    product_name?: string;
     description: string;
     quantity: number;
     unit_price: number;
@@ -136,7 +137,7 @@ export const useOptimizedQuotations = (
       // Fetch quotation items
       const { data: quotationItems } = await supabase
         .from('quotation_items')
-        .select('id, quotation_id, product_id, description, quantity, unit_price, tax_percentage, tax_amount, line_total')
+        .select('id, quotation_id, product_id, product_name, description, quantity, unit_price, tax_percentage, tax_amount, line_total')
         .in('quotation_id', quotations.map((q) => q.id));
 
       // Create maps

--- a/src/hooks/useQuotationItems.ts
+++ b/src/hooks/useQuotationItems.ts
@@ -228,6 +228,7 @@ export const useConvertQuotationToInvoice = () => {
         const invoiceItems = quotation.quotation_items.map((item: any) => ({
           invoice_id: invoice.id,
           product_id: item.product_id,
+          product_name: item.product_name,
           description: item.description,
           quantity: item.quantity,
           unit_price: item.unit_price,


### PR DESCRIPTION
### Summary
This PR fixes missing `product_name` data in quotation and invoice items by including it in database queries and preserving it during quotation-to-invoice conversion.

### Problem
When generating PDFs for quotations and invoices, the item name was not appearing in the table. Although the data was saved correctly in the database, `product_name` was not being fetched in the optimized hooks, causing it to be absent from the rendered output and PDF exports.

### Solution
Added `product_name` to the relevant Supabase select queries and ensured it is carried over when converting a quotation to an invoice.

### Key Changes
- **`useOptimizedQuotations.ts`**: Added `product_name` to the `OptimizedQuotation` item interface and included it in the `quotation_items` select query.
- **`useOptimizedInvoices.ts`**: Added `product_name` to the invoice items select query so it is available for display and PDF generation.
- **`useQuotationItems.ts`**: Included `product_name` when mapping quotation items to invoice items during quotation-to-invoice conversion, preventing recalculation or data loss.


---

<a href="https://builder.io/app/projects/cae844f5a3a34882b815/radiant-guild-sfuqpz43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://cae844f5a3a34882b815-radiant-guild-sfuqpz43.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=cae844f5a3a34882b815&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 76`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>cae844f5a3a34882b815</projectId>-->
<!--<branchName>radiant-guild-sfuqpz43</branchName>-->