### PR TITLE
Fix currency conversion in quotations and invoices

### DIFF
--- a/src/components/invoices/EditInvoiceModal.tsx
+++ b/src/components/invoices/EditInvoiceModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useCurrency } from '@/contexts/CurrencyContext';
 import { normalizeInvoiceAmount } from '@/utils/currency';
 import { getLocaleForCurrency, getExchangeRate } from '@/utils/exchangeRates';
@@ -30,7 +30,8 @@ import {
   Trash2,
   Search,
   Calculator,
-  Receipt
+  Receipt,
+  RefreshCw
 } from 'lucide-react';
 import { useCustomers, useProducts, useTaxSettings } from '@/hooks/useDatabase';
 import { useUpdateInvoiceWithItems } from '@/hooks/useQuotationItems';
@@ -64,29 +65,13 @@ interface EditInvoiceModalProps {
 export function EditInvoiceModal({ open, onOpenChange, onSuccess, invoice }: EditInvoiceModalProps) {
   const { currency, rate } = useCurrency();
 
-  const formatInvoiceCurrency = (amount: number) => {
-    const invoiceCurrency = invoice?.currency_code || 'KES';
-    const normalized = normalizeInvoiceAmount(
-      amount,
-      invoiceCurrency as any,
-      invoice?.exchange_rate,
-      invoiceCurrency as any,
-      rate
-    );
-    return new Intl.NumberFormat(getLocaleForCurrency(invoiceCurrency as any), {
-      style: 'currency',
-      currency: invoiceCurrency,
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 0,
-    }).format(Number.isFinite(normalized) ? normalized : 0);
-  };
   const [selectedCustomerId, setSelectedCustomerId] = useState('');
   const [invoiceDate, setInvoiceDate] = useState('');
   const [dueDate, setDueDate] = useState('');
   const [lpoNumber, setLpoNumber] = useState('');
   const [notes, setNotes] = useState('');
   const [termsAndConditions, setTermsAndConditions] = useState('');
-  
+
   const [items, setItems] = useState<InvoiceItem[]>([]);
   const [searchProduct, setSearchProduct] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -94,6 +79,78 @@ export function EditInvoiceModal({ open, onOpenChange, onSuccess, invoice }: Edi
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [recalculateWithCurrentRate, setRecalculateWithCurrentRate] = useState(false);
   const [lockedRateInfo, setLockedRateInfo] = useState<{ rate: number; date: string } | null>(null);
+
+  const [currencyCode, setCurrencyCode] = useState<'KES' | 'USD'>(invoice?.currency_code || 'KES');
+  const [exchangeRate, setExchangeRate] = useState<number>(invoice?.exchange_rate || 1);
+  const previousRateRef = useRef<number>(1);
+
+  const formatInvoiceCurrency = (amount: number) => {
+    const normalized = normalizeInvoiceAmount(
+      amount,
+      currencyCode as any,
+      exchangeRate,
+      currencyCode as any,
+      rate
+    );
+    return new Intl.NumberFormat(getLocaleForCurrency(currencyCode as any), {
+      style: 'currency',
+      currency: currencyCode,
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    }).format(Number.isFinite(normalized) ? normalized : 0);
+  };
+
+  const convertItemsByFactor = (factor: number) => {
+    setItems(prev => prev.map(item => {
+      const newUnit = parseFloat((item.unit_price * factor).toFixed(4));
+      const { lineTotal, taxAmount } = calculateLineTotal(item, undefined, newUnit);
+      return { ...item, unit_price: newUnit, line_total: lineTotal, tax_amount: taxAmount };
+    }));
+  };
+
+  const handleCurrencyChange = async (newCurrency: 'KES' | 'USD') => {
+    try {
+      if (newCurrency === currencyCode) return;
+      let newRate = 1;
+      if (newCurrency === 'USD') {
+        toast.info('Fetching USD/KES exchange rate...');
+        newRate = await getExchangeRate('USD', 'KES', invoiceDate);
+        if (!newRate || newRate <= 0) throw new Error('Invalid rate');
+        toast.success(`Rate locked: 1 USD = ${newRate.toFixed(2)} KES`);
+      } else {
+        newRate = 1;
+      }
+      const factor = newRate / previousRateRef.current;
+      convertItemsByFactor(factor);
+      previousRateRef.current = newRate;
+      setExchangeRate(newRate);
+      setCurrencyCode(newCurrency);
+    } catch (e: any) {
+      console.error('Currency change failed:', e);
+      toast.error(e?.message || 'Failed to change currency');
+    }
+  };
+
+  const fetchAndSetRate = async () => {
+    try {
+      toast.info('Fetching exchange rate...');
+      const rate = currencyCode === 'USD'
+        ? await getExchangeRate('USD', 'KES', invoiceDate)
+        : 1;
+      if (!rate || rate <= 0) throw new Error('Invalid exchange rate');
+      const factor = rate / exchangeRate;
+      convertItemsByFactor(factor);
+      previousRateRef.current = rate;
+      setExchangeRate(rate);
+      const msg = currencyCode === 'USD'
+        ? `Rate updated: 1 USD = ${rate.toFixed(2)} KES`
+        : 'Currency set to KES (no conversion needed)';
+      toast.success(msg);
+    } catch (e: any) {
+      console.error('Failed to fetch rate:', e);
+      toast.error(e?.message || 'Failed to fetch exchange rate');
+    }
+  };
 
   const { currentCompany } = useCurrentCompany();
   const { data: customers, isLoading: loadingCustomers } = useCustomers(currentCompany?.id);
@@ -116,6 +173,13 @@ export function EditInvoiceModal({ open, onOpenChange, onSuccess, invoice }: Edi
       setLpoNumber(invoice.lpo_number || '');
       setNotes(invoice.notes || '');
       setTermsAndConditions(invoice.terms_and_conditions || '');
+
+      // Initialize currency and exchange rate from invoice
+      const invoiceCurrency = invoice.currency_code || 'KES';
+      const invoiceRate = invoice.exchange_rate || 1;
+      setCurrencyCode(invoiceCurrency);
+      setExchangeRate(invoiceRate);
+      previousRateRef.current = invoiceRate;
 
       // Capture locked rate info if invoice was created in USD
       if (invoice.currency_code === 'USD' && invoice.exchange_rate) {
@@ -422,6 +486,9 @@ export function EditInvoiceModal({ open, onOpenChange, onSuccess, invoice }: Edi
         balance_due: balanceDue,
         terms_and_conditions: termsAndConditions,
         notes: notes,
+        currency_code: currencyCode,
+        exchange_rate: exchangeRate,
+        fx_date: invoiceDate
       };
 
       // If invoice was in USD and recalculated, update the rate metadata
@@ -482,6 +549,39 @@ export function EditInvoiceModal({ open, onOpenChange, onSuccess, invoice }: Edi
                 <CardTitle className="text-lg">Invoice Details</CardTitle>
               </CardHeader>
               <CardContent className="space-y-4">
+                {/* Currency Selection */}
+                <div className="space-y-2">
+                  <Label htmlFor="currency">Currency</Label>
+                  <div className="flex gap-2">
+                    <Select value={currencyCode} onValueChange={handleCurrencyChange}>
+                      <SelectTrigger className="flex-1">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="KES">KES - Kenyan Shilling</SelectItem>
+                        <SelectItem value="USD">USD - US Dollar</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    {currencyCode === 'USD' && (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={fetchAndSetRate}
+                        className="px-3"
+                        title="Fetch latest exchange rate"
+                      >
+                        <RefreshCw className="h-4 w-4" />
+                      </Button>
+                    )}
+                  </div>
+                  {currencyCode === 'USD' && exchangeRate && (
+                    <p className="text-xs text-muted-foreground">
+                      Rate: 1 USD = {exchangeRate.toFixed(2)} KES
+                    </p>
+                  )}
+                </div>
+
                 {/* Locked Rate Info (for USD invoices) */}
                 {lockedRateInfo && invoice?.currency_code === 'USD' && (
                   <div className="p-3 bg-blue-50 border border-blue-200 rounded-lg">

--- a/src/components/quotations/CreateQuotationModal.tsx
+++ b/src/components/quotations/CreateQuotationModal.tsx
@@ -117,20 +117,25 @@ export function CreateQuotationModal({ open, onOpenChange, onSuccess }: CreateQu
     try {
       if (newCurrency === currencyCode) return;
       let newRate = 1;
-      if (newCurrency === 'USD' && items.length > 0) {
-        // Only fetch and apply exchange rate if there are items to convert
-        toast.info('Fetching KES→USD rate...');
-        newRate = await getExchangeRate('KES', 'USD', quotationDate);
-        if (!newRate || newRate <= 0) throw new Error('Invalid rate');
-        toast.success(`Rate locked: 1 KES = ${newRate.toFixed(6)} USD`);
-        const factor = newRate / previousRateRef.current;
-        convertItemsByFactor(factor);
+      if (newCurrency === 'USD') {
+        if (items.length > 0) {
+          // Fetch exchange rate only if there are items to convert
+          toast.info('Fetching KES→USD rate...');
+          newRate = await getExchangeRate('KES', 'USD', quotationDate);
+          if (!newRate || newRate <= 0) throw new Error('Invalid rate');
+          toast.success(`Rate locked: 1 KES = ${newRate.toFixed(6)} USD`);
+          const factor = newRate / previousRateRef.current;
+          convertItemsByFactor(factor);
+        }
+        // If no items, newRate stays at 1 (placeholder rate until items are added)
       } else if (newCurrency === 'KES') {
+        // Switching back to KES: always convert items back
         newRate = 1;
-        const factor = newRate / previousRateRef.current;
-        convertItemsByFactor(factor);
+        if (items.length > 0) {
+          const factor = newRate / previousRateRef.current;
+          convertItemsByFactor(factor);
+        }
       }
-      // If switching to USD with no items, keep rate at 1 (no conversion needed)
       previousRateRef.current = newRate;
       setExchangeRate(newRate);
       setCurrencyCode(newCurrency);

--- a/src/components/quotations/EditQuotationModal.tsx
+++ b/src/components/quotations/EditQuotationModal.tsx
@@ -101,15 +101,24 @@ export function EditQuotationModal({ open, onOpenChange, onSuccess, quotation }:
       if (newCurrency === currencyCode) return;
       let newRate = 1;
       if (newCurrency === 'USD') {
-        toast.info('Fetching KES→USD rate...');
-        newRate = await getExchangeRate('KES', 'USD', quotationDate);
-        if (!newRate || newRate <= 0) throw new Error('Invalid rate');
-        toast.success(`Rate locked: 1 KES = ${newRate.toFixed(6)} USD`);
-      } else {
+        if (items.length > 0) {
+          // Fetch exchange rate only if there are items to convert
+          toast.info('Fetching KES→USD rate...');
+          newRate = await getExchangeRate('KES', 'USD', quotationDate);
+          if (!newRate || newRate <= 0) throw new Error('Invalid rate');
+          toast.success(`Rate locked: 1 KES = ${newRate.toFixed(6)} USD`);
+          const factor = newRate / previousRateRef.current;
+          convertItemsByFactor(factor);
+        }
+        // If no items, newRate stays at 1 (placeholder rate until items are added)
+      } else if (newCurrency === 'KES') {
+        // Switching back to KES: always convert items back
         newRate = 1;
+        if (items.length > 0) {
+          const factor = newRate / previousRateRef.current;
+          convertItemsByFactor(factor);
+        }
       }
-      const factor = newRate / previousRateRef.current;
-      convertItemsByFactor(factor);
       previousRateRef.current = newRate;
       setExchangeRate(newRate);
       setCurrencyCode(newCurrency);

--- a/src/hooks/useQuotationItems.ts
+++ b/src/hooks/useQuotationItems.ts
@@ -211,7 +211,7 @@ export const useConvertQuotationToInvoice = () => {
         terms_and_conditions: quotation.terms_and_conditions,
         affects_inventory: true,
         currency_code: (quotation as any).currency_code,
-        exchange_rate: quotationRate ? (1 / quotationRate) : 1,
+        exchange_rate: quotationRate || 1,
         fx_date: (quotation as any).quotation_date || new Date().toISOString().split('T')[0]
       };
       


### PR DESCRIPTION
### Summary
This PR fixes currency conversion logic across quotation and invoice modals, ensuring item prices are correctly converted when switching between KES and USD, and that exchange rates are properly preserved when converting quotations to invoices.

### Problem
When selecting USD as the currency in the Create or Edit Quotation modals, item prices were not being converted — the currency symbol changed but no rate conversion was applied. Additionally, when a USD quotation was converted to an invoice, the exchange rate was incorrectly inverted (`1 / rate` instead of `rate`), causing wrong amounts on the resulting invoice. The Edit Invoice modal also lacked currency selection and conversion support entirely.

### Solution
- Guarded currency conversion logic to only run `convertItemsByFactor` when items actually exist, preventing unnecessary fetches or errors on empty forms.
- Fixed the exchange rate passed during quotation-to-invoice conversion by removing the erroneous inversion.
- Added full currency selection and exchange rate management to `EditInvoiceModal`, mirroring the pattern used in quotation modals.

### Key Changes
- **`CreateQuotationModal.tsx`**: Refactored `handleCurrencyChange` to only fetch and apply the exchange rate when items are present; switching back to KES also guards against empty item lists.
- **`EditQuotationModal.tsx`**: Applied the same guarded conversion logic as `CreateQuotationModal` — fetch rate and convert only when items exist.
- **`EditInvoiceModal.tsx`**:
  - Added `currencyCode`, `exchangeRate`, and `previousRateRef` state/ref for currency management.
  - Added `convertItemsByFactor`, `handleCurrencyChange`, and `fetchAndSetRate` functions.
  - Added a currency selector UI with a refresh button and live rate display.
  - Initialized currency/rate state from the existing invoice on load.
  - Included `currency_code`, `exchange_rate`, and `fx_date` in the invoice update payload.
- **`useQuotationItems.ts`**: Fixed `exchange_rate` in `useConvertQuotationToInvoice` — removed the incorrect `1 / quotationRate` inversion, now passes `quotationRate || 1` directly.


---

<a href="https://builder.io/app/projects/da3ff6556ee243669098/patchwork-landing-qtczkr9q"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://da3ff6556ee243669098-patchwork-landing-qtczkr9q.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=da3ff6556ee243669098&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 77`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>da3ff6556ee243669098</projectId>-->
<!--<branchName>patchwork-landing-qtczkr9q</branchName>-->