### PR TITLE
Fix session clear on page refresh for data-heavy pages

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -197,18 +197,12 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         context: 'handleAuthStateChange'
       });
 
-      // Only clear tokens for genuine Supabase auth errors, not external API errors
-      if (isErrorType(error, 'auth')) {
-        const errorMessage = getUserFriendlyErrorMessage(error);
-        // Check for explicit Supabase auth token errors
-        if (errorMessage.includes('Invalid Refresh Token') ||
-            errorMessage.includes('Refresh Token Not Found') ||
-            errorMessage.includes('invalid_token') ||
-            errorMessage.includes('invalid_grant')) {
-          clearAuthTokens();
-        }
-        // Don't clear tokens on generic network/fetch errors - these are external API failures
+      // CRITICAL: Only clear tokens for genuine Supabase refresh token errors, NOT RLS/query errors
+      if (isErrorType(error, 'refreshTokenError')) {
+        console.warn('🧹 Clearing auth tokens due to invalid/expired refresh token');
+        clearAuthTokens();
       }
+      // Do NOT clear tokens on RLS errors, permission errors, or network errors from data queries
     } finally {
       if (mountedRef.current) {
         setLoading(false);
@@ -359,13 +353,10 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       } catch (error) {
         console.warn('⚠️ Quick auth check failed:', error);
 
-        // Handle specific error types silently
-        if (error instanceof Error) {
-          if (error.message.includes('Invalid Refresh Token') ||
-              error.message.includes('invalid_token')) {
-            console.warn('🧹 Clearing invalid tokens (silent)');
-            clearAuthTokens();
-          }
+        // CRITICAL: Only clear tokens for refresh token errors, not network/permission errors
+        if (isErrorType(error, 'refreshTokenError')) {
+          console.warn('🧹 Clearing invalid tokens due to refresh token error (silent)');
+          clearAuthTokens();
         }
 
         // Don't show errors - app will start anyway

--- a/src/pages/Invoices.tsx
+++ b/src/pages/Invoices.tsx
@@ -50,6 +50,7 @@ import {
 } from 'lucide-react';
 import { useCompanies, useDeleteInvoice } from '@/hooks/useDatabase';
 import { useOptimizedInvoices } from '@/hooks/useOptimizedInvoices';
+import { useAuth } from '@/contexts/AuthContext';
 import { toast } from 'sonner';
 import { parseErrorMessage } from '@/utils/errorHelpers';
 import { DeleteConfirmationModal } from '@/components/DeleteConfirmationModal';
@@ -99,6 +100,8 @@ function getStatusColor(status: string) {
 }
 
 export default function Invoices() {
+  const { loading: authLoading } = useAuth();
+
   const [searchTerm, setSearchTerm] = useState('');
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
@@ -124,16 +127,19 @@ export default function Invoices() {
   const [currentPage, setCurrentPage] = useState(1);
   const PAGE_SIZE = 20;
 
-  const { data: companies } = useCompanies();
+  // CRITICAL: Only query data after auth has finished initializing to prevent race condition on page refresh
+  const { data: companies, isLoading: companiesLoading } = authLoading
+    ? { data: undefined, isLoading: true }
+    : useCompanies();
   const currentCompany = companies?.[0];
 
-  // Use the optimized invoices hook with pagination
+  // CRITICAL: Only query invoices after auth is ready. Pass undefined for companyId while loading to prevent query
   const {
     data: invoiceData,
     isLoading,
     error,
     refetch
-  } = useOptimizedInvoices(currentCompany?.id, {
+  } = useOptimizedInvoices(authLoading ? undefined : currentCompany?.id, {
     page: currentPage,
     pageSize: PAGE_SIZE,
     searchTerm,
@@ -468,6 +474,18 @@ Website: www.biolegendscientific.co.ke`;
     toast.success('Filters cleared');
   };
 
+  // Show loading state while auth is initializing (prevents race condition on page refresh)
+  if (authLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto mb-4" />
+          <p className="text-muted-foreground">Initializing session...</p>
+        </div>
+      </div>
+    );
+  }
+
   if (error) {
     return (
       <div className="space-y-6">
@@ -481,8 +499,8 @@ Website: www.biolegendscientific.co.ke`;
           <CardContent className="pt-6">
             <div className="text-center py-8">
               <p className="text-destructive">Error loading invoices: {parseErrorMessage(error)}</p>
-              <Button 
-                variant="outline" 
+              <Button
+                variant="outline"
                 onClick={() => refetch()}
                 className="mt-4"
               >

--- a/src/pages/Quotations.tsx
+++ b/src/pages/Quotations.tsx
@@ -110,9 +110,13 @@ export default function Quotations() {
 
   // Get current user and company from context
   const { profile, loading: authLoading } = useAuth();
-  const { data: companies } = useCompanies();
+  // CRITICAL: Only query data after auth has finished initializing to prevent race condition on page refresh
+  const { data: companies, isLoading: companiesLoading } = authLoading
+    ? { data: undefined, isLoading: true }
+    : useCompanies();
   const currentCompany = companies?.[0];
-  const { data: quotationData, isLoading, error, refetch } = useOptimizedQuotations(currentCompany?.id, {
+  // CRITICAL: Only query quotations after auth is ready. Pass undefined for companyId while loading to prevent query
+  const { data: quotationData, isLoading, error, refetch } = useOptimizedQuotations(authLoading ? undefined : currentCompany?.id, {
     page: currentPage,
     pageSize: PAGE_SIZE,
     searchTerm,
@@ -364,6 +368,18 @@ Website: www.biolegendscientific.co.ke`;
     toast.info('Advanced filter functionality coming soon!');
   };
 
+  // Show loading state while auth is initializing (prevents race condition on page refresh)
+  if (authLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto mb-4" />
+          <p className="text-muted-foreground">Initializing session...</p>
+        </div>
+      </div>
+    );
+  }
+
   if (error) {
     return (
       <div className="space-y-6">
@@ -377,8 +393,8 @@ Website: www.biolegendscientific.co.ke`;
           <CardContent className="pt-6">
             <div className="text-center py-8">
               <p className="text-destructive">Error loading quotations: {error.message}</p>
-              <Button 
-                variant="outline" 
+              <Button
+                variant="outline"
                 onClick={() => window.location.reload()}
                 className="mt-4"
               >

--- a/src/utils/errorLogger.ts
+++ b/src/utils/errorLogger.ts
@@ -70,36 +70,55 @@ export const getUserFriendlyErrorMessage = (error: unknown): string => {
 
 /**
  * Checks if an error is a specific type (e.g., auth, network, permission)
+ * CRITICAL: auth type is specifically for Supabase auth token errors (refresh token failures),
+ * NOT for RLS/query permission errors. RLS errors should be classified as 'permission'.
  */
-export const isErrorType = (error: unknown, type: 'auth' | 'network' | 'permission' | 'validation'): boolean => {
+export const isErrorType = (error: unknown, type: 'auth' | 'network' | 'permission' | 'validation' | 'refreshTokenError'): boolean => {
   const message = getUserFriendlyErrorMessage(error).toLowerCase();
-  
+  const errorObj = error && typeof error === 'object' ? (error as any) : null;
+  const errorCode = errorObj?.code || '';
+
   switch (type) {
+    case 'refreshTokenError':
+      // CRITICAL: Only match explicit refresh token errors from Supabase auth operations
+      return message.includes('invalid refresh token') ||
+             message.includes('refresh token not found') ||
+             message.includes('invalid_token') ||
+             message.includes('invalid_grant') ||
+             errorCode === 'invalid_token' ||
+             errorCode === 'invalid_grant';
+
     case 'auth':
-      return message.includes('jwt') || 
-             message.includes('token') || 
-             message.includes('unauthorized') ||
-             message.includes('authentication') ||
-             message.includes('invalid_token');
-             
+      // CRITICAL: JWT/auth header errors ONLY - NOT RLS errors
+      // Do NOT match 'unauthorized' or generic 'token' (too broad, catches RLS)
+      return message.includes('jwt') ||
+             message.includes('invalid jwt') ||
+             message.includes('malformed jwt') ||
+             message.includes('authentication required') ||
+             (message.includes('invalid') && message.includes('jwt'));
+
     case 'network':
-      return message.includes('fetch') || 
-             message.includes('network') || 
+      return message.includes('fetch') ||
+             message.includes('network') ||
              message.includes('connection') ||
              message.includes('timeout');
-             
+
     case 'permission':
-      return message.includes('permission') || 
-             message.includes('unauthorized') || 
+      // RLS and data-layer permission errors - do NOT clear auth tokens
+      return message.includes('permission') ||
              message.includes('row level security') ||
-             message.includes('access denied');
-             
+             message.includes('rls') ||
+             message.includes('access denied') ||
+             message.includes('new row violates row-level security') ||
+             errorCode === 'PGRST301' || // RLS policy violation
+             errorCode === 'PGRST201';   // Not authenticated (data, not auth token)
+
     case 'validation':
-      return message.includes('validation') || 
-             message.includes('required') || 
+      return message.includes('validation') ||
+             message.includes('required') ||
              message.includes('invalid') ||
              message.includes('constraint');
-             
+
     default:
       return false;
   }


### PR DESCRIPTION
### Summary
Fixes a race condition on page refresh where data query errors on the Invoices and Quotations pages incorrectly triggered auth token clearing, logging users out and requiring a new token request.

### Problem
When refreshing the browser on data-heavy pages (Invoices, Quotations), Supabase session restoration was still in progress when data queries fired. Query/RLS errors from those in-flight requests were being misclassified as auth token errors, causing `clearAuthTokens()` to be called and wiping the session before restoration could complete. This forced users to request a new token rather than simply re-logging in.

### Solution
Two complementary fixes were applied:
1. **Tighten token-clearing logic** — Auth tokens are now only cleared for genuine Supabase refresh token failures, not for RLS/query/network errors.
2. **Gate data fetches behind auth readiness** — Invoices and Quotations pages now wait for auth initialization to complete before firing any data queries, eliminating the race condition entirely.

### Key Changes
- **`src/utils/errorLogger.ts`**: Added a new `refreshTokenError` error type that precisely matches only Supabase refresh token failures (`invalid_grant`, `invalid_token`, `refresh token not found`). Narrowed the `auth` type to genuine JWT errors only. Expanded the `permission` type to explicitly cover RLS error codes (`PGRST301`, `PGRST201`) so they are never mistaken for auth errors.
- **`src/contexts/AuthContext.tsx`**: Replaced broad `isErrorType(error, 'auth')` + string matching with the new `isErrorType(error, 'refreshTokenError')` check in both `handleAuthStateChange` and the quick auth check, ensuring `clearAuthTokens()` is never called on RLS or network errors.
- **`src/pages/Invoices.tsx`**: Imports `useAuth` and reads `authLoading`; conditionally skips `useCompanies()` and passes `undefined` as `companyId` to `useOptimizedInvoices` while auth is loading. Renders a spinner with "Initializing session…" until auth is ready.
- **`src/pages/Quotations.tsx`**: Same auth-readiness guard applied — `useCompanies()` and `useOptimizedQuotations()` are skipped until `authLoading` is `false`, with an identical loading spinner shown in the interim.


---

<a href="https://builder.io/app/projects/2cd77997c9da432bbe5d/dim-hill-y6cyspx6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://2cd77997c9da432bbe5d-dim-hill-y6cyspx6.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=2cd77997c9da432bbe5d&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 79`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2cd77997c9da432bbe5d</projectId>-->
<!--<branchName>dim-hill-y6cyspx6</branchName>-->