### PR TITLE
Implement server-side auto-send email for documents

### DIFF
--- a/src/components/delivery/ViewDeliveryNoteModal.tsx
+++ b/src/components/delivery/ViewDeliveryNoteModal.tsx
@@ -22,7 +22,8 @@ import {
   MapPin,
   CheckCircle,
   Clock,
-  AlertTriangle
+  AlertTriangle,
+  Loader2
 } from 'lucide-react';
 
 interface DeliveryItem {
@@ -62,6 +63,7 @@ interface ViewDeliveryNoteModalProps {
   onDownloadPDF?: (deliveryNote: DeliveryNote) => void;
   onSendEmail?: (deliveryNote: DeliveryNote) => void;
   onMarkDelivered?: (deliveryNote: DeliveryNote) => void;
+  isSending?: boolean;
 }
 
 export const ViewDeliveryNoteModal = ({
@@ -70,7 +72,8 @@ export const ViewDeliveryNoteModal = ({
   deliveryNote,
   onDownloadPDF,
   onSendEmail,
-  onMarkDelivered
+  onMarkDelivered,
+  isSending
 }: ViewDeliveryNoteModalProps) => {
   if (!deliveryNote) return null;
 
@@ -354,8 +357,12 @@ export const ViewDeliveryNoteModal = ({
               <Download className="h-4 w-4 mr-2" />
               Download PDF
             </Button>
-            <Button variant="outline" onClick={handleSendEmail}>
-              <Send className="h-4 w-4 mr-2" />
+            <Button variant="outline" onClick={handleSendEmail} disabled={isSending}>
+              {isSending ? (
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+              ) : (
+                <Send className="h-4 w-4 mr-2" />
+              )}
               Send Email
             </Button>
             {mappedDeliveryNote.status !== 'delivered' && (

--- a/src/components/invoices/ViewInvoiceModal.tsx
+++ b/src/components/invoices/ViewInvoiceModal.tsx
@@ -12,7 +12,7 @@ import { normalizeInvoiceAmount } from '@/utils/currency';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
-import { 
+import {
   Receipt,
   Calendar,
   User,
@@ -23,7 +23,8 @@ import {
   Download,
   Send,
   DollarSign,
-  Edit
+  Edit,
+  Loader2
 } from 'lucide-react';
 
 interface ViewInvoiceModalProps {
@@ -34,16 +35,18 @@ interface ViewInvoiceModalProps {
   onDownload: () => void;
   onSend: () => void;
   onRecordPayment: () => void;
+  isSending?: boolean;
 }
 
-export function ViewInvoiceModal({ 
-  open, 
-  onOpenChange, 
-  invoice, 
-  onEdit, 
-  onDownload, 
-  onSend, 
-  onRecordPayment 
+export function ViewInvoiceModal({
+  open,
+  onOpenChange,
+  invoice,
+  onEdit,
+  onDownload,
+  onSend,
+  onRecordPayment,
+  isSending
 }: ViewInvoiceModalProps) {
   if (!invoice) return null;
 
@@ -113,8 +116,12 @@ export function ViewInvoiceModal({
                 Download
               </Button>
               {invoice.customers?.email && invoice.status === 'draft' && (
-                <Button variant="outline" size="sm" onClick={onSend}>
-                  <Send className="h-4 w-4 mr-2" />
+                <Button variant="outline" size="sm" onClick={onSend} disabled={isSending}>
+                  {isSending ? (
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  ) : (
+                    <Send className="h-4 w-4 mr-2" />
+                  )}
                   Send
                 </Button>
               )}

--- a/src/components/quotations/ViewQuotationModal.tsx
+++ b/src/components/quotations/ViewQuotationModal.tsx
@@ -21,7 +21,8 @@ import {
   Edit,
   Send,
   CheckCircle,
-  X
+  X,
+  Loader2
 } from 'lucide-react';
 import { BiolegendLogo } from '@/components/ui/biolegend-logo';
 import { useCompanies } from '@/hooks/useDatabase';
@@ -36,6 +37,7 @@ interface ViewQuotationModalProps {
   onSend: () => void;
   onAccept?: () => void;
   onReject?: () => void;
+  isSending?: boolean;
 }
 
 export function ViewQuotationModal({
@@ -46,7 +48,8 @@ export function ViewQuotationModal({
   onDownload,
   onSend,
   onAccept,
-  onReject
+  onReject,
+  isSending
 }: ViewQuotationModalProps) {
   // Get company data for logo (hooks must be called unconditionally)
   const { data: companies } = useCompanies();
@@ -115,8 +118,12 @@ export function ViewQuotationModal({
                   <Download className="h-4 w-4" />
                 </Button>
                 {quotation.status === 'draft' && (
-                  <Button variant="outline" size="sm" onClick={onSend}>
-                    <Send className="h-4 w-4" />
+                  <Button variant="outline" size="sm" onClick={onSend} disabled={isSending}>
+                    {isSending ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <Send className="h-4 w-4" />
+                    )}
                   </Button>
                 )}
                 {quotation.status === 'sent' && onAccept && (

--- a/src/pages/DeliveryNotes.tsx
+++ b/src/pages/DeliveryNotes.tsx
@@ -36,16 +36,19 @@ import {
   Clock,
   AlertTriangle,
   MapPin,
-  Trash2
+  Trash2,
+  Loader2
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { downloadDeliveryNotePDF } from '@/utils/pdfGenerator';
+import { sendDeliveryNoteEmail } from '@/utils/emailService';
 import { CreateDeliveryNoteModal } from '@/components/delivery/CreateDeliveryNoteModal';
 import { ViewDeliveryNoteModal } from '@/components/delivery/ViewDeliveryNoteModal';
 import { DeleteConfirmationModal } from '@/components/DeleteConfirmationModal';
 import { useUpdateDeliveryNote, useCompanies } from '@/hooks/useDatabase';
 import { useOptimizedDeliveryNotes } from '@/hooks/useOptimizedDeliveryNotes';
 import { mapDeliveryNoteForDisplay } from '@/utils/deliveryNoteMapper';
+import { useCurrency } from '@/contexts/CurrencyContext';
 import { supabase } from '@/integrations/supabase/client';
 
 
@@ -57,6 +60,7 @@ export default function DeliveryNotes() {
   const [deliveryNoteToDelete, setDeliveryNoteToDelete] = useState(null);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [sendingDeliveryNoteId, setSendingDeliveryNoteId] = useState<string | null>(null);
 
   // Pagination state
   const [currentPage, setCurrentPage] = useState(1);
@@ -65,6 +69,7 @@ export default function DeliveryNotes() {
   // Database hooks
   const { data: companies } = useCompanies();
   const currentCompany = companies?.[0];
+  const { rate } = useCurrency();
 
   // Use optimized delivery notes hook with server-side pagination
   const { data: deliveryNoteData, isLoading, error, refetch } = useOptimizedDeliveryNotes(currentCompany?.id, {
@@ -140,14 +145,32 @@ export default function DeliveryNotes() {
     }
   };
 
-  const handleSendEmail = (deliveryNote: any) => {
+  const handleSendEmail = async (deliveryNote: any) => {
+    if (!deliveryNote.customers?.email) {
+      toast.error('Customer email not available');
+      return;
+    }
+
     const noteNumber = deliveryNote.delivery_note_number || deliveryNote.delivery_number;
-    const subject = `Delivery Note ${noteNumber}`;
-    const body = `Please find attached delivery note ${noteNumber} for your shipment.`;
-    const emailUrl = `mailto:${deliveryNote.customers?.email}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
-    
-    window.open(emailUrl);
-    toast.success(`Email client opened with delivery note ${noteNumber}`);
+    setSendingDeliveryNoteId(deliveryNote.id);
+
+    try {
+      await sendDeliveryNoteEmail(
+        noteNumber,
+        deliveryNote.customers.email,
+        deliveryNote.customers.name,
+        deliveryNote.id
+      );
+
+      toast.success(`Email sent to ${deliveryNote.customers.email}`);
+      refetch();
+    } catch (error) {
+      console.error('Error sending delivery note:', error);
+      const message = error instanceof Error ? error.message : 'Failed to send email. Please try again.';
+      toast.error(message);
+    } finally {
+      setSendingDeliveryNoteId(null);
+    }
   };
 
   const handleMarkDelivered = async (deliveryNote: any) => {
@@ -449,9 +472,13 @@ export default function DeliveryNotes() {
                           variant="ghost"
                           size="sm"
                           onClick={() => handleSendEmail(note)}
-                          disabled={!note.customers?.email}
+                          disabled={!note.customers?.email || sendingDeliveryNoteId === note.id}
                         >
-                          <Send className="h-4 w-4" />
+                          {sendingDeliveryNoteId === note.id ? (
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                          ) : (
+                            <Send className="h-4 w-4" />
+                          )}
                         </Button>
                         {note.status !== 'delivered' && (
                           <Button
@@ -567,6 +594,7 @@ export default function DeliveryNotes() {
         onDownloadPDF={handleDownloadPDF}
         onSendEmail={handleSendEmail}
         onMarkDelivered={handleMarkDelivered}
+        isSending={!!selectedDeliveryNote && sendingDeliveryNoteId === selectedDeliveryNote.id}
       />
 
       {/* Delete Confirmation Modal */}

--- a/src/pages/Invoices.tsx
+++ b/src/pages/Invoices.tsx
@@ -46,7 +46,8 @@ import {
   Calendar,
   Receipt,
   Truck,
-  Trash2
+  Trash2,
+  Loader2
 } from 'lucide-react';
 import { useCompanies, useDeleteInvoice } from '@/hooks/useDatabase';
 import { useOptimizedInvoices } from '@/hooks/useOptimizedInvoices';
@@ -60,6 +61,7 @@ import { ViewInvoiceModal } from '@/components/invoices/ViewInvoiceModal';
 import { RecordPaymentModal } from '@/components/payments/RecordPaymentModal';
 import { CreateDeliveryNoteModal } from '@/components/delivery/CreateDeliveryNoteModal';
 import { downloadInvoicePDF } from '@/utils/pdfGenerator';
+import { sendInvoiceEmail } from '@/utils/emailService';
 import { useCurrency } from '@/contexts/CurrencyContext';
 import { normalizeInvoiceAmount } from '@/utils/currency';
 import { supabase } from '@/integrations/supabase/client';
@@ -114,6 +116,7 @@ export default function Invoices() {
   const [selectedInvoices, setSelectedInvoices] = useState<Set<string>>(new Set());
   const [invoicesToBulkDelete, setInvoicesToBulkDelete] = useState<Invoice[]>([]);
   const [showBulkDeleteConfirm, setShowBulkDeleteConfirm] = useState(false);
+  const [sendingInvoiceId, setSendingInvoiceId] = useState<string | null>(null);
 
   // Filter states
   const [statusFilter, setStatusFilter] = useState('all');
@@ -240,42 +243,33 @@ export default function Invoices() {
       return;
     }
 
+    setSendingInvoiceId(invoiceData.id);
+
     try {
-      // Create email content
-      const subject = `Invoice ${invoiceData.invoice_number} from Biolegend Scientific LTD`;
-      const body = `Dear ${invoiceData.customers.name},
+      await sendInvoiceEmail(
+        invoiceData.invoice_number,
+        invoiceData.customers.email,
+        invoiceData.customers.name,
+        invoiceData.id
+      );
 
-Please find attached your invoice ${invoiceData.invoice_number} dated ${new Date(invoiceData.invoice_date).toLocaleDateString()}.
+      const updateResult = await supabase
+        .from('invoices')
+        .update({ status: 'sent' })
+        .eq('id', invoiceData.id);
 
-Invoice Summary:
-- Invoice Amount: ${displayAmount(invoiceData.total_amount || 0, invoiceData.currency_code as any, invoiceData.exchange_rate as any)}
-- Due Date: ${new Date(invoiceData.due_date).toLocaleDateString()}
-- Balance Due: ${displayAmount(invoiceData.balance_due || 0, invoiceData.currency_code as any, invoiceData.exchange_rate as any)}
+      if (updateResult.error) {
+        console.error('Error updating invoice status:', updateResult.error);
+      }
 
-Payment can be made via:
-- Bank Transfer
-- Mobile Money (M-Pesa)
-- Cheque
-
-If you have any questions about this invoice, please don't hesitate to contact us.
-
-Best regards,
-Biolegend Scientific Ltd Team
-Tel: 0741 207 690/0780 165 490
-Email: biolegend@biolegendscientific.co.ke/info@biolegendscientific.co.ke
-Website: www.biolegendscientific.co.ke`;
-
-      // Open email client with pre-filled content
-      const emailUrl = `mailto:${invoiceData.customers.email}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
-      window.open(emailUrl, '_blank');
-
-      toast.success(`Email client opened with invoice ${invoiceData.invoice_number} for ${invoiceData.customers.email}`);
-
-      // TODO: In a real app, update invoice status to 'sent'
-
+      toast.success(`Email sent to ${invoiceData.customers.email}`);
+      refetch();
     } catch (error) {
       console.error('Error sending invoice:', error);
-      toast.error('Failed to send invoice email. Please try again.');
+      const message = error instanceof Error ? error.message : 'Failed to send email. Please try again.';
+      toast.error(message);
+    } finally {
+      setSendingInvoiceId(null);
     }
   };
 
@@ -835,9 +829,14 @@ Website: www.biolegendscientific.co.ke`;
                                 variant="outline"
                                 size="sm"
                                 onClick={() => handleSendInvoice(invoice.id)}
+                                disabled={sendingInvoiceId === invoice.id}
                                 className="bg-primary-light text-primary border-primary/20 hover:bg-primary hover:text-primary-foreground"
                               >
-                                <Send className="h-4 w-4 mr-1" />
+                                {sendingInvoiceId === invoice.id ? (
+                                  <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+                                ) : (
+                                  <Send className="h-4 w-4 mr-1" />
+                                )}
                                 Send
                               </Button>
                             )}
@@ -964,6 +963,7 @@ Website: www.biolegendscientific.co.ke`;
           onDownload={() => handleDownloadInvoice(selectedInvoice)}
           onSend={() => handleSendInvoice(selectedInvoice.id)}
           onRecordPayment={() => handleRecordPayment(selectedInvoice.id)}
+          isSending={!!selectedInvoice && sendingInvoiceId === selectedInvoice.id}
         />
       )}
 

--- a/src/pages/LPOs.tsx
+++ b/src/pages/LPOs.tsx
@@ -38,12 +38,14 @@ import {
   FileText,
   User,
   Database,
-  Trash2
+  Trash2,
+  Loader2
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { useUpdateLPO, useCompanies, useDeleteLPO } from '@/hooks/useDatabase';
 import { useOptimizedLPOs } from '@/hooks/useOptimizedLPOs';
 import { downloadLPOPDF } from '@/utils/pdfGenerator';
+import { sendLPOEmail } from '@/utils/emailService';
 import { CreateLPOModal } from '@/components/lpo/CreateLPOModal';
 import { ViewLPOModal } from '@/components/lpo/ViewLPOModal';
 import { EditLPOModal } from '@/components/lpo/EditLPOModal';
@@ -65,6 +67,7 @@ export default function LPOs() {
   const [showCustomerSupplierAudit, setShowCustomerSupplierAudit] = useState(false);
   const [lpoToDelete, setLpoToDelete] = useState(null);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [sendingLPOId, setSendingLPOId] = useState<string | null>(null);
 
   // Pagination state
   const [currentPage, setCurrentPage] = useState(1);
@@ -146,13 +149,31 @@ export default function LPOs() {
     }
   };
 
-  const handleSendEmail = (lpo: any) => {
-    const subject = `Purchase Order ${lpo.lpo_number}`;
-    const body = `Please find attached Purchase Order ${lpo.lpo_number} for your review.`;
-    const emailUrl = `mailto:${lpo.suppliers?.email}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
-    
-    window.open(emailUrl);
-    toast.success(`Email client opened with LPO ${lpo.lpo_number}`);
+  const handleSendEmail = async (lpo: any) => {
+    if (!lpo.suppliers?.email) {
+      toast.error('Supplier email not available');
+      return;
+    }
+
+    setSendingLPOId(lpo.id);
+
+    try {
+      await sendLPOEmail(
+        lpo.lpo_number,
+        lpo.suppliers.email,
+        lpo.suppliers.name,
+        lpo.id
+      );
+
+      toast.success(`Email sent to ${lpo.suppliers.email}`);
+      refetch();
+    } catch (error) {
+      console.error('Error sending LPO:', error);
+      const message = error instanceof Error ? error.message : 'Failed to send email. Please try again.';
+      toast.error(message);
+    } finally {
+      setSendingLPOId(null);
+    }
   };
 
   const handleUpdateStatus = async (lpo: any, newStatus: string) => {
@@ -512,9 +533,13 @@ export default function LPOs() {
                           variant="ghost"
                           size="sm"
                           onClick={() => handleSendEmail(lpo)}
-                          disabled={!lpo.suppliers?.email}
+                          disabled={!lpo.suppliers?.email || sendingLPOId === lpo.id}
                         >
-                          <Send className="h-4 w-4" />
+                          {sendingLPOId === lpo.id ? (
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                          ) : (
+                            <Send className="h-4 w-4" />
+                          )}
                         </Button>
                         {lpo.status === 'approved' && (
                           <Button
@@ -634,6 +659,7 @@ export default function LPOs() {
         onDownloadPDF={handleDownloadPDF}
         onSendEmail={handleSendEmail}
         onUpdateStatus={handleUpdateStatus}
+        isSending={!!selectedLPO && sendingLPOId === selectedLPO.id}
       />
 
       <EditLPOModal

--- a/src/pages/Quotations.tsx
+++ b/src/pages/Quotations.tsx
@@ -31,7 +31,8 @@ import {
   Download,
   Calendar,
   Send,
-  Trash2
+  Trash2,
+  Loader2
 } from 'lucide-react';
 import { DeleteConfirmationModal } from '@/components/DeleteConfirmationModal';
 import { useCompanies, useUpdateQuotationStatus, useDeleteQuotation } from '@/hooks/useDatabase';
@@ -43,6 +44,7 @@ import { CreateQuotationModal } from '@/components/quotations/CreateQuotationMod
 import { ViewQuotationModal } from '@/components/quotations/ViewQuotationModal';
 import { EditQuotationModal } from '@/components/quotations/EditQuotationModal';
 import { downloadQuotationPDF } from '@/utils/pdfGenerator';
+import { sendQuotationEmail } from '@/utils/emailService';
 import { CreateInvoiceModal } from '@/components/invoices/CreateInvoiceModal';
 import { supabase } from '@/integrations/supabase/client';
 import { CheckCircle, X } from 'lucide-react';
@@ -106,6 +108,7 @@ export default function Quotations() {
   const [quotationToDelete, setQuotationToDelete] = useState<Quotation | null>(null);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
+  const [sendingQuotationId, setSendingQuotationId] = useState<string | null>(null);
   const PAGE_SIZE = 20;
 
   // Get current user and company from context
@@ -193,58 +196,29 @@ export default function Quotations() {
       return;
     }
 
+    setSendingQuotationId(quotation.id);
+
     try {
-      // Create email content
-      const subject = `Quotation ${quotation.quotation_number} from Biolegend Scientific LTD`;
-      const body = `Dear ${quotation.customers.name},
+      await sendQuotationEmail(
+        quotation.quotation_number,
+        quotation.customers.email,
+        quotation.customers.name,
+        quotation.id
+      );
 
-Please find attached your quotation ${quotation.quotation_number} dated ${new Date(quotation.quotation_date).toLocaleDateString()}.
-
-Quotation Summary:
-- Total Amount: KES ${quotation.total_amount?.toLocaleString() || '0'}
-- Valid Until: ${quotation.valid_until ? new Date(quotation.valid_until).toLocaleDateString() : 'No expiry'}
-
-If you have any questions about this quotation, please don't hesitate to contact us.
-
-Best regards,
-Biolegend Scientific Ltd Team
-Tel: 0741 207 690/0780 165 490
-Email: biolegend@biolegendscientific.co.ke/info@biolegendscientific.co.ke
-Website: www.biolegendscientific.co.ke`;
-
-      // Open email client with pre-filled content
-      const emailUrl = `mailto:${quotation.customers.email}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
-      window.open(emailUrl, '_blank');
-
-      // Update quotation status to 'sent'
       await updateQuotationStatus.mutateAsync({
         quotationId: quotation.id,
         status: 'sent',
       });
 
-      toast.success(`Quotation ${quotation.quotation_number} sent and status updated to "Sent"`);
+      toast.success(`Email sent to ${quotation.customers.email}`);
       refetch();
     } catch (error) {
       console.error('Error sending quotation:', error);
-
-      let errorMessage = 'Please try again.';
-
-      if (error instanceof Error) {
-        errorMessage = error.message;
-      } else if (error && typeof error === 'object') {
-        const supabaseError = error as any;
-        if (supabaseError.message) {
-          errorMessage = supabaseError.message;
-        } else if (supabaseError.details) {
-          errorMessage = supabaseError.details;
-        } else if (supabaseError.hint) {
-          errorMessage = supabaseError.hint;
-        } else {
-          errorMessage = JSON.stringify(error);
-        }
-      }
-
-      toast.error(`Failed to send quotation: ${errorMessage}`);
+      const message = error instanceof Error ? error.message : 'Failed to send email. Please try again.';
+      toast.error(message);
+    } finally {
+      setSendingQuotationId(null);
     }
   };
 
@@ -594,9 +568,14 @@ Website: www.biolegendscientific.co.ke`;
                               variant="outline"
                               size="sm"
                               onClick={() => handleSendQuotation(quotation)}
+                              disabled={sendingQuotationId === quotation.id}
                               className="bg-primary-light text-primary border-primary/20 hover:bg-primary hover:text-primary-foreground"
                             >
-                              <Send className="h-4 w-4 mr-1" />
+                              {sendingQuotationId === quotation.id ? (
+                                <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+                              ) : (
+                                <Send className="h-4 w-4 mr-1" />
+                              )}
                               <span className="hidden sm:inline">Send</span>
                             </Button>
                           )}
@@ -736,6 +715,7 @@ Website: www.biolegendscientific.co.ke`;
         onSend={() => selectedQuotation && handleSendQuotation(selectedQuotation)}
         onAccept={() => selectedQuotation && handleAcceptQuotation(selectedQuotation)}
         onReject={() => selectedQuotation && handleRejectQuotation(selectedQuotation)}
+        isSending={!!selectedQuotation && sendingQuotationId === selectedQuotation.id}
       />
 
       <EditQuotationModal

--- a/src/utils/emailService.ts
+++ b/src/utils/emailService.ts
@@ -1,0 +1,115 @@
+import { supabase } from '@/integrations/supabase/client';
+import {
+  generateInvoiceEmail,
+  generateQuotationEmail,
+  generateBiolegendEmailSignature,
+} from './biolegendEmailTemplates';
+
+interface SendEmailParams {
+  to: string;
+  subject: string;
+  body: string;
+  documentType: 'invoice' | 'quotation' | 'delivery_note' | 'lpo';
+  documentId: string;
+}
+
+async function sendEmailViaEdgeFunction(params: SendEmailParams) {
+  try {
+    const response = await supabase.functions.invoke('send-email', {
+      body: {
+        to: params.to,
+        subject: params.subject,
+        body: params.body,
+        documentType: params.documentType,
+        documentId: params.documentId,
+      },
+    });
+
+    if (response.error) {
+      throw new Error(response.error.message || 'Failed to send email');
+    }
+
+    return response.data;
+  } catch (error) {
+    console.error('Email service error:', error);
+    throw error;
+  }
+}
+
+export async function sendInvoiceEmail(
+  invoiceNumber: string,
+  customerEmail: string,
+  customerName: string,
+  invoiceId: string
+) {
+  const emailTemplate = generateInvoiceEmail(invoiceNumber, customerName);
+
+  return sendEmailViaEdgeFunction({
+    to: customerEmail,
+    subject: emailTemplate.subject,
+    body: emailTemplate.body,
+    documentType: 'invoice',
+    documentId: invoiceId,
+  });
+}
+
+export async function sendQuotationEmail(
+  quotationNumber: string,
+  customerEmail: string,
+  customerName: string,
+  quotationId: string
+) {
+  const emailTemplate = generateQuotationEmail(quotationNumber, customerName);
+
+  return sendEmailViaEdgeFunction({
+    to: customerEmail,
+    subject: emailTemplate.subject,
+    body: emailTemplate.body,
+    documentType: 'quotation',
+    documentId: quotationId,
+  });
+}
+
+export async function sendDeliveryNoteEmail(
+  deliveryNoteNumber: string,
+  customerEmail: string,
+  customerName: string,
+  deliveryNoteId: string
+) {
+  const subject = `Delivery Note ${deliveryNoteNumber} from Biolegend Scientific Ltd`;
+  const body = `Dear ${customerName},
+
+Please find attached delivery note ${deliveryNoteNumber} for your shipment.
+
+${generateBiolegendEmailSignature()}`;
+
+  return sendEmailViaEdgeFunction({
+    to: customerEmail,
+    subject,
+    body,
+    documentType: 'delivery_note',
+    documentId: deliveryNoteId,
+  });
+}
+
+export async function sendLPOEmail(
+  lpoNumber: string,
+  supplierEmail: string,
+  supplierName: string,
+  lpoId: string
+) {
+  const subject = `Purchase Order ${lpoNumber} from Biolegend Scientific Ltd`;
+  const body = `Dear ${supplierName},
+
+Please find attached Purchase Order ${lpoNumber} for your review and processing.
+
+${generateBiolegendEmailSignature()}`;
+
+  return sendEmailViaEdgeFunction({
+    to: supplierEmail,
+    subject,
+    body,
+    documentType: 'lpo',
+    documentId: lpoId,
+  });
+}

--- a/supabase/functions/send-email/index.ts
+++ b/supabase/functions/send-email/index.ts
@@ -1,0 +1,114 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import * as nodemailer from "npm:nodemailer@6.9.7";
+
+interface EmailPayload {
+  to: string;
+  subject: string;
+  body: string;
+  html?: string;
+  documentType: 'invoice' | 'quotation' | 'delivery_note' | 'lpo';
+  documentId: string;
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  if (req.method !== 'POST') {
+    return new Response('Method not allowed', {
+      status: 405,
+      headers: corsHeaders,
+    });
+  }
+
+  try {
+    const payload: EmailPayload = await req.json();
+
+    // Validate required fields
+    if (!payload.to || !payload.subject || !payload.body) {
+      return new Response(
+        JSON.stringify({
+          error: 'Missing required fields: to, subject, body',
+        }),
+        { status: 400, headers: corsHeaders }
+      );
+    }
+
+    // Get SMTP configuration from environment variables
+    const smtpHost = Deno.env.get('SMTP_HOST');
+    const smtpPort = parseInt(Deno.env.get('SMTP_PORT') || '587', 10);
+    const smtpUsername = Deno.env.get('SMTP_USERNAME');
+    const smtpPassword = Deno.env.get('SMTP_PASSWORD');
+    const smtpFromEmail = Deno.env.get('SMTP_FROM_EMAIL');
+    const smtpFromName = Deno.env.get('SMTP_FROM_NAME') || 'Biolegend Scientific';
+
+    // Validate SMTP configuration
+    if (!smtpHost || !smtpUsername || !smtpPassword || !smtpFromEmail) {
+      console.error('Missing SMTP configuration', {
+        host: !!smtpHost,
+        username: !!smtpUsername,
+        password: !!smtpPassword,
+        from: !!smtpFromEmail,
+      });
+
+      return new Response(
+        JSON.stringify({
+          error: 'SMTP configuration not properly set',
+        }),
+        { status: 500, headers: corsHeaders }
+      );
+    }
+
+    // Create transporter
+    const transporter = nodemailer.createTransport({
+      host: smtpHost,
+      port: smtpPort,
+      secure: smtpPort === 465,
+      auth: {
+        user: smtpUsername,
+        pass: smtpPassword,
+      },
+    });
+
+    // Send email
+    const info = await transporter.sendMail({
+      from: `${smtpFromName} <${smtpFromEmail}>`,
+      to: payload.to,
+      subject: payload.subject,
+      text: payload.body,
+      html: payload.html || payload.body.replace(/\n/g, '<br>'),
+    });
+
+    console.log('Email sent:', {
+      messageId: info.messageId,
+      to: payload.to,
+      documentType: payload.documentType,
+      documentId: payload.documentId,
+    });
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        messageId: info.messageId,
+        to: payload.to,
+      }),
+      { status: 200, headers: corsHeaders }
+    );
+  } catch (error) {
+    console.error('Error sending email:', error);
+
+    return new Response(
+      JSON.stringify({
+        error: error instanceof Error ? error.message : 'Unknown error',
+      }),
+      { status: 500, headers: corsHeaders }
+    );
+  }
+});
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+};


### PR DESCRIPTION
### Summary
Replaces client-side `mailto:` links with server-side automatic email sending for Invoices, Quotations, and Delivery Notes, giving users immediate feedback via toasts and loading states instead of opening their email client.

### Problem
Previously, clicking "Send" on invoices, quotations, and delivery notes opened a `mailto:` link relying on the user's local email client to actually deliver the message. This meant no guarantee of delivery, no audit trail, and status updates depended on manual user action.

### Solution
Added a Supabase Edge Function that sends emails via SMTP (nodemailer), and a frontend `emailService` utility that calls this function. Updated the relevant pages and modals to call the new service directly, show a loading spinner while sending, and surface success/error feedback via toasts.

### Key Changes
- **New Edge Function** `supabase/functions/send-email/index.ts`: accepts `{ to, subject, body, documentType, documentId }`, sends email via nodemailer using SMTP env vars (`SMTP_HOST`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD`, `SMTP_FROM_EMAIL`, `SMTP_FROM_NAME`), and returns success/error responses with CORS handling.
- **New client utility** `src/utils/emailService.ts` with `sendInvoiceEmail`, `sendQuotationEmail`, `sendDeliveryNoteEmail`, and `sendLPOEmail` functions that invoke the Edge Function and build email content using existing Biolegend email templates.
- **DeliveryNotes.tsx**: `handleSendEmail` now calls `sendDeliveryNoteEmail` instead of opening a `mailto:` link, tracks a `sendingDeliveryNoteId` state to disable the button and show a spinner, and shows success/error toasts.
- **Invoices.tsx / Quotations.tsx**: `handleSendQuotation`/send handlers updated to call the email service, update document status to "sent" on success, and manage a per-item sending state for loading indicators.
- **View modals** (`ViewInvoiceModal`, `ViewQuotationModal`, `ViewDeliveryNoteModal`): added `isSending` prop to disable the Send button and show a `Loader2` spinner while the email request is in flight.
- Removed manual `mailto:` URL construction and window.open calls across the updated pages.


---

<a href="https://builder.io/app/projects/56bb87187eaf4751bcc1/twisted-finger-paxhyjei"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://56bb87187eaf4751bcc1-twisted-finger-paxhyjei.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=56bb87187eaf4751bcc1&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 83`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>56bb87187eaf4751bcc1</projectId>-->
<!--<branchName>twisted-finger-paxhyjei</branchName>-->