### PR TITLE
Fix currency normalization for proformas, credit notes, and receipts

### DIFF
--- a/src/components/credit-notes/EditCreditNoteModal.tsx
+++ b/src/components/credit-notes/EditCreditNoteModal.tsx
@@ -27,7 +27,7 @@ import {
 import { useUpdateCreditNote } from '@/hooks/useCreditNotes';
 import { toast } from 'sonner';
 import { useCurrency } from '@/contexts/CurrencyContext';
-import { convertAmount } from '@/utils/currency';
+import { normalizeInvoiceAmount } from '@/utils/currency';
 import type { CreditNote } from '@/hooks/useCreditNotes';
 
 interface EditCreditNoteModalProps {
@@ -63,8 +63,11 @@ export function EditCreditNoteModal({
     }
   }, [creditNote, open]);
 
-  const { currency, rate, format } = useCurrency();
-  const formatCurrency = (amount: number) => format(convertAmount(Number(amount) || 0, 'KES', currency, rate));
+  const { rate, format } = useCurrency();
+  const formatCurrency = (amount: number) => {
+    const documentCurrency = creditNote?.currency_code || 'KES';
+    return format(normalizeInvoiceAmount(Number(amount) || 0, documentCurrency, creditNote?.exchange_rate, documentCurrency, rate), documentCurrency);
+  };
 
   if (!creditNote) return null;
 

--- a/src/components/invoices/CreateInvoiceModal.tsx
+++ b/src/components/invoices/CreateInvoiceModal.tsx
@@ -70,9 +70,10 @@ interface CreateInvoiceModalProps {
   sourceQuotationId?: string;
   initialCurrencyCode?: 'KES' | 'USD';
   initialExchangeRate?: number;
+  initialFxDate?: string;
 }
 
-export function CreateInvoiceModal({ open, onOpenChange, onSuccess, preSelectedCustomer, initialItems, initialNotes, initialTerms, initialLpoNumber, initialInvoiceDate, initialDueDate, sourceQuotationId, initialCurrencyCode, initialExchangeRate }: CreateInvoiceModalProps) {
+export function CreateInvoiceModal({ open, onOpenChange, onSuccess, preSelectedCustomer, initialItems, initialNotes, initialTerms, initialLpoNumber, initialInvoiceDate, initialDueDate, sourceQuotationId, initialCurrencyCode, initialExchangeRate, initialFxDate }: CreateInvoiceModalProps) {
   const [selectedCustomerId, setSelectedCustomerId] = useState(preSelectedCustomer?.id || '');
   const [invoiceDate, setInvoiceDate] = useState(new Date().toISOString().split('T')[0]);
   const [dueDate, setDueDate] = useState(
@@ -160,6 +161,8 @@ export function CreateInvoiceModal({ open, onOpenChange, onSuccess, preSelectedC
       if (typeof initialInvoiceDate === 'string') {
         console.log('✅ Setting invoice date:', initialInvoiceDate);
         setInvoiceDate(initialInvoiceDate);
+      } else if (typeof initialFxDate === 'string') {
+        setInvoiceDate(initialFxDate);
       }
       if (typeof initialDueDate === 'string') {
         console.log('✅ Setting due date:', initialDueDate);
@@ -171,7 +174,7 @@ export function CreateInvoiceModal({ open, onOpenChange, onSuccess, preSelectedC
         previousRateRef.current = initialExchangeRate;
       }
     }
-  }, [open, preSelectedCustomer, initialItems, initialNotes, initialTerms, initialLpoNumber, initialInvoiceDate, initialDueDate, initialExchangeRate]);
+  }, [open, preSelectedCustomer, initialItems, initialNotes, initialTerms, initialLpoNumber, initialInvoiceDate, initialDueDate, initialExchangeRate, initialFxDate]);
 
   // Inherit global currency selection when opening the modal (unless initial currency was specified)
   useEffect(() => {

--- a/src/components/proforma/ViewProformaModal.tsx
+++ b/src/components/proforma/ViewProformaModal.tsx
@@ -23,7 +23,8 @@ import {
   DollarSign,
   AlertTriangle
 } from 'lucide-react';
-import { formatCurrency } from '@/utils/taxCalculation';
+import { useCurrency } from '@/contexts/CurrencyContext';
+import { normalizeInvoiceAmount } from '@/utils/currency';
 
 interface ProformaItem {
   id: string;
@@ -54,6 +55,9 @@ interface Proforma {
     address?: string;
   };
   proforma_items?: ProformaItem[];
+  currency_code?: 'KES' | 'USD';
+  exchange_rate?: number;
+  fx_date?: string;
 }
 
 interface ViewProformaModalProps {
@@ -73,7 +77,12 @@ export const ViewProformaModal = ({
   onSendEmail,
   onCreateInvoice
 }: ViewProformaModalProps) => {
+  const { rate, format } = useCurrency();
   if (!proforma) return null;
+  const formatCurrency = (amount: number) => {
+    const documentCurrency = proforma.currency_code || 'KES';
+    return format(normalizeInvoiceAmount(Number(amount) || 0, documentCurrency, proforma.exchange_rate, documentCurrency, rate), documentCurrency);
+  };
 
   // 🔍 Deduplicate items for display
   const { deduplicatedItems, hasDuplicates, duplicateCount } = useMemo(() => {

--- a/src/components/receipts/ViewReceiptModal.tsx
+++ b/src/components/receipts/ViewReceiptModal.tsx
@@ -38,11 +38,14 @@ export function ViewReceiptModal({
 }: ViewReceiptModalProps) {
   if (!receipt) return null;
 
-  const { currency, rate, format } = useCurrency();
-  const formatCurrency = (amount: number) => format(
-    normalizeInvoiceAmount(Number(amount) || 0, receipt?.currency_code as any, receipt?.exchange_rate as any, receipt?.currency_code as any, 1),
-    receipt?.currency_code
-  );
+  const { rate, format } = useCurrency();
+  const formatCurrency = (amount: number) => {
+    const documentCurrency = receipt?.currency_code || 'KES';
+    return format(
+      normalizeInvoiceAmount(Number(amount) || 0, documentCurrency, receipt?.exchange_rate, documentCurrency, rate),
+      documentCurrency
+    );
+  };
 
   const formatDate = (dateString: string) => {
     return new Date(dateString).toLocaleDateString('en-GB', {
@@ -168,6 +171,12 @@ export function ViewReceiptModal({
                 <div className="flex justify-between">
                   <span className="text-muted-foreground">Currency:</span>
                   <span className="font-semibold">{receipt.currency_code}</span>
+                </div>
+              )}
+              {receipt.currency_code === 'USD' && receipt.exchange_rate && (
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Exchange Rate:</span>
+                  <span className="font-semibold">1 USD = {Number(receipt.exchange_rate).toFixed(2)} KES</span>
                 </div>
               )}
             </CardContent>

--- a/src/hooks/useCreditNotes.ts
+++ b/src/hooks/useCreditNotes.ts
@@ -19,6 +19,9 @@ export interface CreditNote {
   affects_inventory: boolean;
   notes?: string;
   terms_and_conditions?: string;
+  currency_code?: 'KES' | 'USD';
+  exchange_rate?: number;
+  fx_date?: string;
   created_by?: string;
   created_at: string;
   updated_at: string;

--- a/src/hooks/useOptimizedCreditNotes.ts
+++ b/src/hooks/useOptimizedCreditNotes.ts
@@ -18,6 +18,9 @@ export interface OptimizedCreditNote {
   reason?: string;
   notes?: string;
   terms_and_conditions?: string;
+  currency_code?: 'KES' | 'USD';
+  exchange_rate?: number;
+  fx_date?: string;
   created_by?: string;
   created_at?: string;
   updated_at?: string;
@@ -80,6 +83,9 @@ export const useOptimizedCreditNotes = (
           reason,
           notes,
           terms_and_conditions,
+          currency_code,
+          exchange_rate,
+          fx_date,
           created_by,
           created_at,
           updated_at

--- a/src/hooks/useOptimizedProformas.ts
+++ b/src/hooks/useOptimizedProformas.ts
@@ -20,6 +20,7 @@ export interface OptimizedProforma {
   updated_at?: string;
   currency_code?: 'KES' | 'USD';
   exchange_rate?: number;
+  fx_date?: string;
   customers?: {
     id: string;
     name: string;
@@ -82,6 +83,7 @@ export const useOptimizedProformas = (
           terms_and_conditions,
           currency_code,
           exchange_rate,
+          fx_date,
           created_by,
           created_at,
           updated_at

--- a/src/hooks/useProforma.ts
+++ b/src/hooks/useProforma.ts
@@ -40,6 +40,7 @@ export interface ProformaInvoice {
   updated_at?: string;
   currency_code?: 'KES' | 'USD';
   exchange_rate?: number;
+  fx_date?: string;
 }
 
 export interface ProformaWithItems extends ProformaInvoice {

--- a/src/pages/CreditNotes.tsx
+++ b/src/pages/CreditNotes.tsx
@@ -52,7 +52,7 @@ import { DeleteConfirmationModal } from '@/components/DeleteConfirmationModal';
 import { useCompanies } from '@/hooks/useDatabase';
 import { useCurrency } from '@/contexts/CurrencyContext';
 import { supabase } from '@/integrations/supabase/client';
-import { convertAmount } from '@/utils/currency';
+import { normalizeInvoiceAmount } from '@/utils/currency';
 import { useOptimizedCreditNotes } from '@/hooks/useOptimizedCreditNotes';
 import { toast } from 'sonner';
 import { CreateCreditNoteModal } from '@/components/credit-notes/CreateCreditNoteModal';
@@ -133,7 +133,10 @@ export default function CreditNotes() {
   const filteredCreditNotes = creditNotes;
 
   const { currency, rate, format } = useCurrency();
-  const formatCurrency = (amount: number) => format(convertAmount(Number(amount) || 0, 'KES', currency, rate));
+  const formatCurrency = (amount: number, recordCurrency?: 'KES' | 'USD', recordRate?: number) => {
+    const documentCurrency = recordCurrency || 'KES';
+    return format(normalizeInvoiceAmount(Number(amount) || 0, documentCurrency, recordRate, documentCurrency, rate), documentCurrency);
+  };
 
   const handleCreateSuccess = () => {
     refetch();
@@ -544,13 +547,13 @@ export default function CreditNotes() {
                       <span className="text-sm">{creditNote.reason || 'Not specified'}</span>
                     </TableCell>
                     <TableCell className="font-semibold text-success">
-                      {formatCurrency(creditNote.total_amount || 0)}
+                      {formatCurrency(creditNote.total_amount || 0, creditNote.currency_code, creditNote.exchange_rate)}
                     </TableCell>
                     <TableCell className="text-warning">
-                      {formatCurrency(creditNote.applied_amount || 0)}
+                      {formatCurrency(creditNote.applied_amount || 0, creditNote.currency_code, creditNote.exchange_rate)}
                     </TableCell>
                     <TableCell className={`font-medium ${(creditNote.balance || 0) > 0 ? 'text-success' : 'text-muted-foreground'}`}>
-                      {formatCurrency(creditNote.balance || 0)}
+                      {formatCurrency(creditNote.balance || 0, creditNote.currency_code, creditNote.exchange_rate)}
                     </TableCell>
                     <TableCell>
                       <Badge variant="outline" className={getStatusColor(creditNote.status)}>

--- a/src/pages/Proforma.tsx
+++ b/src/pages/Proforma.tsx
@@ -63,7 +63,7 @@ import { ensureProformaSchema } from '@/utils/proformaDatabaseSetup';
 import { fixAllProformaDuplicates } from '@/utils/proformaDeduplication';
 import { recalculateAllProformaTotals } from '@/utils/proformaRecalculation';
 import { useCurrency } from '@/contexts/CurrencyContext';
-import { convertAmount } from '@/utils/currency';
+import { normalizeInvoiceAmount } from '@/utils/currency';
 
 export default function Proforma() {
   const [showCreateModal, setShowCreateModal] = useState(false);
@@ -72,7 +72,7 @@ export default function Proforma() {
   const [selectedProforma, setSelectedProforma] = useState<any>(null);
   const [searchTerm, setSearchTerm] = useState('');
   const [showCreateInvoiceModal, setShowCreateInvoiceModal] = useState(false);
-  const [invoicePrefill, setInvoicePrefill] = useState<{ customer: any | null; items: any[]; notes?: string; terms?: string; invoiceDate?: string; dueDate?: string } | null>(null);
+  const [invoicePrefill, setInvoicePrefill] = useState<{ customer: any | null; items: any[]; notes?: string; terms?: string; invoiceDate?: string; dueDate?: string; currencyCode?: 'KES' | 'USD'; exchangeRate?: number; fxDate?: string } | null>(null);
   const [proformaToDelete, setProformaToDelete] = useState<any>(null);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [showRepairPanel, setShowRepairPanel] = useState(false);
@@ -106,7 +106,12 @@ export default function Proforma() {
   const filteredProformas = proformas;
 
   const { currency, rate, format } = useCurrency();
-  const formatCurrency = (amount: number) => format(convertAmount(Number(amount) || 0, 'KES', currency, rate));
+  const displayDocumentAmount = (amount: number, recordCurrency?: 'KES' | 'USD', recordRate?: number) => {
+    const documentCurrency = recordCurrency || 'KES';
+    return format(normalizeInvoiceAmount(Number(amount) || 0, documentCurrency, recordRate, documentCurrency, rate), documentCurrency);
+  };
+  const displaySummaryAmount = (amount: number, recordCurrency?: 'KES' | 'USD', recordRate?: number) =>
+    normalizeInvoiceAmount(Number(amount) || 0, recordCurrency, recordRate, currency, rate);
 
   const getStatusBadge = (status: string) => {
     switch (status) {
@@ -163,6 +168,7 @@ export default function Proforma() {
         terms_and_conditions: proforma.terms_and_conditions || 'Payment required before goods are delivered.',
         currency_code: (proforma as any).currency_code,
         exchange_rate: (proforma as any).exchange_rate,
+        fx_date: (proforma as any).fx_date,
       };
 
       // Get current company details for PDF
@@ -238,7 +244,8 @@ export default function Proforma() {
         invoiceDate: new Date().toISOString().split('T')[0],
         dueDate: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0],
         currencyCode: proforma.currency_code || 'KES',
-        exchangeRate: proforma.exchange_rate || 1
+        exchangeRate: proforma.exchange_rate || 1,
+        fxDate: proforma.fx_date
       };
 
       console.log('💾 Setting invoice prefill from proforma:', invoicePrefillData);
@@ -467,7 +474,7 @@ export default function Proforma() {
               <DollarSign className="h-8 w-8 text-success" />
               <div>
                 <p className="text-2xl font-bold">
-                  {formatCurrency(proformas.reduce((sum, p) => sum + (p.total_amount || 0), 0))}
+                  {format(proformas.reduce((sum, p) => sum + displaySummaryAmount(p.total_amount, p.currency_code, p.exchange_rate), 0))}
                 </p>
                 <p className="text-xs text-muted-foreground">Total Value</p>
               </div>
@@ -684,7 +691,7 @@ export default function Proforma() {
                     <TableCell>
                       <div className="flex items-center font-medium">
                         <DollarSign className="h-4 w-4 mr-1" />
-                        {formatCurrency(proforma.total_amount)}
+                        {displayDocumentAmount(proforma.total_amount, proforma.currency_code, proforma.exchange_rate)}
                       </div>
                     </TableCell>
                     <TableCell>
@@ -892,6 +899,9 @@ export default function Proforma() {
           initialTerms={invoicePrefill.terms}
           initialInvoiceDate={invoicePrefill.invoiceDate}
           initialDueDate={invoicePrefill.dueDate}
+          initialCurrencyCode={invoicePrefill.currencyCode}
+          initialExchangeRate={invoicePrefill.exchangeRate}
+          initialFxDate={invoicePrefill.fxDate}
         />
       )}
 

--- a/src/pages/Receipts.tsx
+++ b/src/pages/Receipts.tsx
@@ -74,6 +74,7 @@ interface Receipt {
   invoice_items?: any[];
   currency_code?: 'KES' | 'USD';
   exchange_rate?: number;
+  fx_date?: string;
 }
 
 function getStatusColor(status: string) {
@@ -164,8 +165,9 @@ export default function Receipts() {
   );
 
   const displayAmount = (amount: number, recordCurrency?: 'KES' | 'USD', receiptRate?: number) => {
-    const normalized = normalizeInvoiceAmount(Number(amount) || 0, recordCurrency as any, receiptRate as any, recordCurrency as any, 1);
-    return format(normalized, recordCurrency || currency);
+    const documentCurrency = recordCurrency || 'KES';
+    const normalized = normalizeInvoiceAmount(Number(amount) || 0, documentCurrency, receiptRate, documentCurrency, rate);
+    return format(normalized, documentCurrency);
   };
 
   const handleCreateSuccess = () => {

--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -1651,6 +1651,8 @@ export const downloadCreditNotePDF = async (creditNote: any, company?: CompanyDe
     date: creditNote.credit_note_date,
     company: company, // Pass company details
     currency_code: creditNoteCurrencyCode,
+    exchange_rate: creditNote.exchange_rate,
+    fx_date: creditNote.fx_date,
     customer: {
       name: creditNote.customers?.name || 'Unknown Customer',
       email: creditNote.customers?.email,
@@ -2153,6 +2155,9 @@ export const downloadLPOPDF = async (lpo: any, company?: CompanyDetails, current
 
 // Function for receipt PDF generation (like invoice but no terms page, just thank you note)
 export const downloadReceiptPDF = async (receipt: any, company?: CompanyDetails, currentRate: number = 1) => {
+  const receiptCurrencyCode = receipt.currency_code === 'USD' || receipt.currency_code === 'KES' ? receipt.currency_code : (Number(receipt.exchange_rate) && Number(receipt.exchange_rate) !== 1 ? 'USD' : 'KES');
+  const receiptRate = Number.isFinite(receipt.exchange_rate) ? receipt.exchange_rate : currentRate;
+  const normalizeReceiptAmount = (amount: number) => normalizeInvoiceAmount(Number(amount) || 0, receiptCurrencyCode, receiptRate, receiptCurrencyCode, currentRate);
   const documentData: DocumentData = {
     type: 'receipt',
     number: receipt.invoice_number,
@@ -2221,7 +2226,9 @@ export const downloadReceiptPDF = async (receipt: any, company?: CompanyDetails,
       return receipt.balance_due !== undefined ? normalizeInvoiceAmount(receipt.balance_due, receiptCurrencyCode, receiptRate, receiptCurrencyCode, currentRate) : 0;
     })(),
     notes: receipt.notes,
-    currency_code: (receipt.currency_code === 'USD' || receipt.currency_code === 'KES' ? receipt.currency_code : (Number(receipt.exchange_rate) && Number(receipt.exchange_rate) !== 1 ? 'USD' : 'KES')),
+    currency_code: receiptCurrencyCode,
+    exchange_rate: receipt.exchange_rate,
+    fx_date: receipt.fx_date,
     terms_and_conditions: 'Thank you for your purchase. This is a sales receipt confirming payment has been received.',
   };
 


### PR DESCRIPTION
### Summary
Fixes currency display and metadata propagation for proformas, credit notes, and receipts so amounts are consistently normalized using each document's locked exchange rate, following the same contract already used for invoices.

### Problem
Proformas, credit notes, and receipts were converting amounts using naive KES-to-current-currency conversion (`convertAmount`) or inconsistent rate arguments, instead of using each document's own persisted `currency_code`/`exchange_rate`. This meant historical USD documents could display incorrect values when the live exchange rate changed, and currency metadata (`currency_code`, `exchange_rate`, `fx_date`) was missing from some queries and types, so it wasn't available for display or PDF generation.

### Solution
Replaced ad-hoc conversion logic with `normalizeInvoiceAmount`, passing each record's own currency and locked rate, mirroring the invoice pattern. Extended types and Supabase queries to carry `currency_code`, `exchange_rate`, and `fx_date` end-to-end, and propagated this metadata through proforma-to-invoice conversion and PDF generation.

### Key Changes
- **EditCreditNoteModal**: switched from `convertAmount` to `normalizeInvoiceAmount`, using the credit note's own `currency_code`/`exchange_rate` instead of the global currency setting.
- **ViewProformaModal**: replaced `formatCurrency` from `taxCalculation` with a normalized formatter based on the proforma's persisted currency metadata; added `currency_code`, `exchange_rate`, `fx_date` to the `Proforma` interface.
- **ViewReceiptModal**: fixed `formatCurrency` to normalize against the active global rate instead of a fixed rate of `1`; added exchange rate display for USD receipts.
- **CreateInvoiceModal**: added `initialFxDate` prop, used to prefill the invoice date when converting from a proforma.
- **Proforma.tsx**: replaced `convertAmount`-based `formatCurrency` with `displayDocumentAmount` (per-row normalization) and `displaySummaryAmount` (aggregate normalization) using `normalizeInvoiceAmount`; passed `fxDate` through to invoice prefill and `CreateInvoiceModal`.
- **CreditNotes.tsx**: replaced `convertAmount`-based `formatCurrency` with a normalization-based version accepting per-record currency/rate; updated table cells to pass each credit note's `currency_code`/`exchange_rate`.
- **Receipts.tsx**: fixed `displayAmount` to use the active global rate instead of a hardcoded `1`, and to always normalize/display in the record's own currency; added `fx_date` to the `Receipt` interface.
- **Hooks (`useCreditNotes`, `useOptimizedCreditNotes`, `useOptimizedProformas`, `useProforma`)**: added `currency_code`, `exchange_rate`, and `fx_date` fields to types and Supabase select queries.
- **pdfGenerator.ts**: added `exchange_rate`/`fx_date` to credit note and receipt PDF payloads, and derived a consistent `receiptCurrencyCode`/`receiptRate` for normalization within `downloadReceiptPDF`.


---

<a href="https://builder.io/app/projects/b1508556dd234542b3dd/parabolic-origin-lwp77bi7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://b1508556dd234542b3dd-parabolic-origin-lwp77bi7.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=b1508556dd234542b3dd&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 86`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b1508556dd234542b3dd</projectId>-->
<!--<branchName>parabolic-origin-lwp77bi7</branchName>-->