### PR TITLE
Add USD currency support to CreateProformaModalOptimized

### DIFF
--- a/src/components/proforma/CreateProformaModalOptimized.tsx
+++ b/src/components/proforma/CreateProformaModalOptimized.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -26,7 +26,8 @@ import {
   Plus,
   Trash2,
   Calculator,
-  Receipt
+  Receipt,
+  Loader2
 } from 'lucide-react';
 import { useCustomers, useProducts, useTaxSettings } from '@/hooks/useDatabase';
 import { useCreateProforma } from '@/hooks/useProforma';
@@ -81,12 +82,15 @@ export const CreateProformaModalOptimized = ({
   const [proformaNumber, setProformaNumber] = useState('');
   const [itemToDelete, setItemToDelete] = useState<ProformaItem | null>(null);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [currencyCode, setCurrencyCode] = useState<'KES' | 'USD'>('KES');
+  const [exchangeRate, setExchangeRate] = useState<number>(1);
+  const previousRateRef = useRef<number>(1);
 
   const { data: customers } = useCustomers(companyId);
   const { data: products } = useProducts(companyId);
   const { data: taxSettings } = useTaxSettings(companyId);
   const createProforma = useCreateProforma();
-  const { currency, rate } = useCurrency();
+  const { currency: globalCurrency, rate } = useCurrency();
   const { newItems, tempIdToActualIdMap, addNewItem, saveAllNewItems, clearNewItems } = useNewItemsAutoSave();
 
   const defaultTaxRate = taxSettings?.find(t => t.is_default)?.rate || 0;
@@ -95,7 +99,7 @@ export const CreateProformaModalOptimized = ({
   useEffect(() => {
     if (open && !proformaNumber) {
       generateProformaNumber();
-      
+
       // Set default valid until date (30 days from today)
       const validUntil = new Date();
       validUntil.setDate(validUntil.getDate() + 30);
@@ -105,6 +109,66 @@ export const CreateProformaModalOptimized = ({
       }));
     }
   }, [open, proformaNumber]);
+
+  // Inherit global currency selection when opening the modal
+  useEffect(() => {
+    if (!open) return;
+    if (globalCurrency && globalCurrency !== currencyCode) {
+      handleCurrencyChange(globalCurrency);
+    }
+  }, [open, globalCurrency]);
+
+  const convertItemsByFactor = (factor: number) => {
+    setItems(prev => prev.map(item => {
+      const newUnit = parseFloat((item.unit_price * factor).toFixed(4));
+      const calculated = calculateItemTax({ ...item, unit_price: newUnit });
+      return { ...item, unit_price: newUnit, line_total: calculated.line_total, tax_amount: calculated.tax_amount };
+    }));
+  };
+
+  const handleCurrencyChange = async (newCurrency: 'KES' | 'USD') => {
+    try {
+      if (newCurrency === currencyCode) return;
+      let newRate = 1;
+      if (newCurrency === 'USD') {
+        toast.info('Fetching USD/KES exchange rate...');
+        newRate = await getExchangeRate('USD', 'KES', formData.proforma_date);
+        if (!newRate || newRate <= 0) throw new Error('Invalid rate');
+        toast.success(`Rate locked: 1 USD = ${newRate.toFixed(2)} KES`);
+      } else {
+        newRate = 1;
+      }
+      const factor = newRate / previousRateRef.current;
+      convertItemsByFactor(factor);
+      previousRateRef.current = newRate;
+      setExchangeRate(newRate);
+      setCurrencyCode(newCurrency);
+    } catch (e: any) {
+      console.error('Currency change failed:', e);
+      toast.error(e?.message || 'Failed to change currency');
+    }
+  };
+
+  const fetchAndSetRate = async () => {
+    try {
+      toast.info('Fetching exchange rate...');
+      const newRate = currencyCode === 'USD'
+        ? await getExchangeRate('USD', 'KES', formData.proforma_date)
+        : 1;
+      if (!newRate || newRate <= 0) throw new Error('Invalid exchange rate');
+      const factor = newRate / exchangeRate;
+      convertItemsByFactor(factor);
+      previousRateRef.current = newRate;
+      setExchangeRate(newRate);
+      const msg = currencyCode === 'USD'
+        ? `Rate updated: 1 USD = ${newRate.toFixed(2)} KES`
+        : 'Currency set to KES (no conversion needed)';
+      toast.success(msg);
+    } catch (e: any) {
+      console.error('Failed to fetch rate:', e);
+      toast.error(e?.message || 'Failed to fetch exchange rate');
+    }
+  };
 
   const generateProformaNumber = async () => {
     try {
@@ -372,13 +436,13 @@ export const CreateProformaModalOptimized = ({
 
     try {
       // Lock FX if USD
-      let effectiveRate = currency === 'USD' ? rate : 1;
-      if (currency === 'USD' && (!Number.isFinite(effectiveRate) || effectiveRate <= 0 || effectiveRate === 1)) {
+      let effectiveRate = currencyCode === 'USD' ? exchangeRate : 1;
+      if (currencyCode === 'USD' && (!Number.isFinite(effectiveRate) || effectiveRate <= 0 || effectiveRate === 1)) {
         try {
-          const fetched = await getExchangeRate('KES', 'USD', formData.proforma_date);
+          const fetched = await getExchangeRate('USD', 'KES', formData.proforma_date);
           if (!fetched || fetched <= 0) throw new Error('Unable to fetch exchange rate for the selected date');
           effectiveRate = fetched;
-          toast.success(`Locked exchange rate for ${formData.proforma_date}: ${fetched.toFixed(4)}`);
+          toast.success(`Locked exchange rate for ${formData.proforma_date}: 1 USD = ${fetched.toFixed(2)} KES`);
         } catch (e: any) {
           toast.error(e?.message || 'Failed to fetch exchange rate');
           throw e;
@@ -396,6 +460,21 @@ export const CreateProformaModalOptimized = ({
       }));
       const totals = calculateDocumentTotals(taxableItems);
 
+      // Store amounts in KES (convert USD to KES for storage) like invoices do
+      const adjustedItems = itemsToSubmit.map(item => ({
+        product_id: item.product_id,
+        product_name: item.product_name,
+        description: item.description,
+        quantity: item.quantity,
+        unit_price: currencyCode === 'USD' ? Number(item.unit_price) * effectiveRate : Number(item.unit_price),
+        discount_percentage: item.discount_percentage || 0,
+        discount_amount: item.discount_amount || 0,
+        tax_percentage: item.tax_percentage,
+        tax_amount: currencyCode === 'USD' ? Number(item.tax_amount || 0) * effectiveRate : Number(item.tax_amount || 0),
+        tax_inclusive: item.tax_inclusive,
+        line_total: currencyCode === 'USD' ? Number(item.line_total) * effectiveRate : Number(item.line_total)
+      }));
+
       // Create proforma invoice using the correct table
       const proformaData = {
         company_id: companyId,
@@ -404,18 +483,18 @@ export const CreateProformaModalOptimized = ({
         proforma_date: formData.proforma_date,
         valid_until: formData.valid_until,
         status: 'draft',
-        subtotal: currency === 'USD' ? convertAmount(totals.subtotal, 'KES', 'USD', effectiveRate) : totals.subtotal,
-        tax_amount: currency === 'USD' ? convertAmount(totals.tax_total, 'KES', 'USD', effectiveRate) : totals.tax_total,
-        total_amount: currency === 'USD' ? convertAmount(totals.total_amount, 'KES', 'USD', effectiveRate) : totals.total_amount,
+        subtotal: currencyCode === 'USD' ? totals.subtotal * effectiveRate : totals.subtotal,
+        tax_amount: currencyCode === 'USD' ? totals.tax_total * effectiveRate : totals.tax_total,
+        total_amount: currencyCode === 'USD' ? totals.total_amount * effectiveRate : totals.total_amount,
         notes: formData.notes,
         terms_and_conditions: formData.terms_and_conditions,
-        currency_code: currency,
-        exchange_rate: currency === 'USD' ? effectiveRate : 1,
+        currency_code: currencyCode,
+        exchange_rate: effectiveRate,
         fx_date: formData.proforma_date
       };
 
       // Create proforma in database with retry logic for duplicate numbers
-      await createProformaWithRetry(proformaData, itemsToSubmit);
+      await createProformaWithRetry(proformaData, adjustedItems);
 
       toast.success('Proforma invoice created successfully!');
       onSuccess?.();
@@ -528,7 +607,7 @@ export const CreateProformaModalOptimized = ({
             </div>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             <div className="space-y-2">
               <Label htmlFor="valid_until">Valid Until</Label>
               <Input
@@ -538,6 +617,41 @@ export const CreateProformaModalOptimized = ({
                 onChange={(e) => setFormData(prev => ({ ...prev, valid_until: e.target.value }))}
               />
             </div>
+            <div className="space-y-2">
+              <Label htmlFor="currency">Currency</Label>
+              <Select value={currencyCode} onValueChange={(v) => handleCurrencyChange(v as 'KES' | 'USD')}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="KES">KES (Kenyan Shilling)</SelectItem>
+                  <SelectItem value="USD">USD (US Dollar)</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            {currencyCode === 'USD' && (
+              <div className="space-y-2">
+                <Label>Exchange Rate</Label>
+                <div className="flex gap-2">
+                  <Input
+                    type="number"
+                    value={exchangeRate}
+                    disabled
+                    className="bg-muted flex-1"
+                  />
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={fetchAndSetRate}
+                    size="sm"
+                    className="px-3"
+                  >
+                    <Loader2 className="h-4 w-4" />
+                  </Button>
+                </div>
+                <p className="text-xs text-muted-foreground">1 USD = {exchangeRate.toFixed(2)} KES</p>
+              </div>
+            )}
           </div>
 
           {/* Items Section */}


### PR DESCRIPTION
### Summary
Adds local currency selection and USD/KES exchange rate locking to `CreateProformaModalOptimized.tsx`, aligning proforma creation with the existing invoice currency behavior.

### Problem
The optimized proforma creation modal only used the global currency/rate values directly, without letting users select or lock a currency per document, and without converting entered item prices when switching currencies. This meant proformas didn't follow the same currency-lock contract used by invoices.

### Solution
Introduced local currency and exchange-rate state in the modal, defaulted from the global currency selection, with logic to fetch and lock the USD/KES rate on currency change and convert existing line items using the rate change factor. On submission, USD-entered amounts (items, tax, subtotal, total) are converted to KES for storage, while the selected currency code, locked exchange rate, and FX date are persisted.

### Key Changes
- Added `currencyCode` and `exchangeRate` local state, replacing direct reliance on the global `currency`/`rate` values within the modal.
- Added `handleCurrencyChange` to fetch/lock the USD/KES rate when switching currency and proportionally convert existing item unit prices/tax/line totals using a `previousRateRef`.
- Added `fetchAndSetRate` to re-fetch and re-lock the exchange rate on demand, with item conversion via the same factor logic.
- Added a `useEffect` to inherit the global currency selection when the modal opens.
- Updated submit logic to build `adjustedItems` with unit price, tax, and line totals converted to KES when currency is USD, and to store `currency_code`, `exchange_rate`, and `fx_date` on the proforma record.
- Fixed exchange rate fetch direction (`USD` → `KES`) and updated success toast messaging to reflect the correct conversion direction.
- Added Currency and Exchange Rate UI fields (select + rate display with refresh button) to the form, adjusting the grid layout to accommodate the new fields.


---

<a href="https://builder.io/app/projects/dd69b10396d94a138e9d/granite-corvette-fbh9uppn"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://dd69b10396d94a138e9d-granite-corvette-fbh9uppn.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=dd69b10396d94a138e9d&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 87`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>dd69b10396d94a138e9d</projectId>-->
<!--<branchName>granite-corvette-fbh9uppn</branchName>-->