### PR TITLE
Fix currency conversion bugs in proformas, credit notes, and receipts

### DIFF
--- a/src/components/credit-notes/CreateCreditNoteModal.tsx
+++ b/src/components/credit-notes/CreateCreditNoteModal.tsx
@@ -131,7 +131,7 @@ export function CreateCreditNoteModal({
       product_name: product.name,
       description: product.description || product.name,
       quantity: 1,
-      unit_price: product.selling_price,
+      unit_price: currency === 'USD' ? convertAmount(product.selling_price, 'KES', 'USD', rate) : product.selling_price,
       tax_percentage: 0,
       tax_amount: 0,
       tax_inclusive: false,
@@ -247,7 +247,7 @@ export function CreateCreditNoteModal({
     setItems(items.filter(item => item.id !== itemId));
   };
 
-  const formatCurrency = (amount: number) => format(convertAmount(Number(amount) || 0, 'KES', currency, rate));
+  const formatCurrency = (amount: number) => format(Number(amount) || 0, currency);
 
   const subtotal = items.reduce((sum, item) => sum + (item.quantity * item.unit_price), 0);
   const taxAmount = items.reduce((sum, item) => sum + (item.tax_amount || 0), 0);
@@ -302,20 +302,19 @@ export function CreateCreditNoteModal({
       let effectiveRate = currency === 'USD' ? rate : 1;
       if (currency === 'USD' && (!Number.isFinite(effectiveRate) || effectiveRate <= 0 || effectiveRate === 1)) {
         try {
-          const fetched = await getExchangeRate('KES', 'USD', creditNoteDate);
+          const fetched = await getExchangeRate('USD', 'KES', creditNoteDate);
           if (!fetched || fetched <= 0) throw new Error('Unable to fetch exchange rate for the selected date');
           effectiveRate = fetched;
-          toast.success(`Locked exchange rate for ${creditNoteDate}: ${fetched.toFixed(4)}`);
+          toast.success(`Locked exchange rate for ${creditNoteDate}: 1 USD = ${fetched.toFixed(2)} KES`);
         } catch (e: any) {
           toast.error(e?.message || 'Failed to fetch exchange rate');
           throw e;
         }
       }
 
-      // Convert amounts if USD
-      const subtotalFinal = currency === 'USD' ? convertAmount(subtotal, 'KES', 'USD', effectiveRate) : subtotal;
-      const taxAmountFinal = currency === 'USD' ? convertAmount(taxAmount, 'KES', 'USD', effectiveRate) : taxAmount;
-      const totalAmountFinal = currency === 'USD' ? convertAmount(totalAmount, 'KES', 'USD', effectiveRate) : totalAmount;
+      const subtotalFinal = currency === 'USD' ? subtotal * effectiveRate : subtotal;
+      const taxAmountFinal = currency === 'USD' ? taxAmount * effectiveRate : taxAmount;
+      const totalAmountFinal = currency === 'USD' ? totalAmount * effectiveRate : totalAmount;
 
       // Create credit note with items
       const creditNoteData = {
@@ -341,9 +340,9 @@ export function CreateCreditNoteModal({
       };
 
       const creditNoteItems = items.map((item, index) => {
-        const unitPriceFinal = currency === 'USD' ? convertAmount(item.unit_price, 'KES', 'USD', effectiveRate) : item.unit_price;
-        const taxAmountFinalItem = currency === 'USD' ? convertAmount(item.tax_amount || 0, 'KES', 'USD', effectiveRate) : (item.tax_amount || 0);
-        const lineTotalFinal = currency === 'USD' ? convertAmount(item.line_total, 'KES', 'USD', effectiveRate) : item.line_total;
+        const unitPriceFinal = currency === 'USD' ? item.unit_price * effectiveRate : item.unit_price;
+        const taxAmountFinalItem = currency === 'USD' ? (item.tax_amount || 0) * effectiveRate : (item.tax_amount || 0);
+        const lineTotalFinal = currency === 'USD' ? item.line_total * effectiveRate : item.line_total;
         return {
           product_id: item.product_id || null,
           description: item.description,

--- a/src/components/proforma/EditProformaModal.tsx
+++ b/src/components/proforma/EditProformaModal.tsx
@@ -38,6 +38,7 @@ import { cleanupProformaDuplicatesSQL } from '@/utils/proformaDuplicateCleanupSQ
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
 import { DeleteConfirmationModal } from '@/components/DeleteConfirmationModal';
+import { normalizeInvoiceAmount } from '@/utils/currency';
 
 interface ProformaItem extends BaseProformaItem {
   // Extends the base ProformaItem with any additional UI-specific fields if needed
@@ -60,6 +61,9 @@ interface Proforma {
     email?: string;
   };
   proforma_items?: ProformaItem[];
+  currency_code?: 'KES' | 'USD';
+  exchange_rate?: number;
+  fx_date?: string;
 }
 
 interface EditProformaModalProps {
@@ -119,6 +123,9 @@ export const EditProformaModal = ({
         status: proforma.status,
       });
 
+      const documentCurrency = proforma.currency_code || 'KES';
+      const documentRate = proforma.exchange_rate || 1;
+
       if (proforma.proforma_items && proforma.proforma_items.length > 0) {
         console.log('📥 Loading items from proforma:', {
           count: proforma.proforma_items.length,
@@ -165,13 +172,13 @@ export const EditProformaModal = ({
               product_name: item.product_name || '',
               description: item.description || '',
               quantity: Number(item.quantity) || 0,  // Ensure it's a number
-              unit_price: Number(item.unit_price) || 0,
+              unit_price: normalizeInvoiceAmount(Number(item.unit_price) || 0, documentCurrency, documentRate, documentCurrency, documentRate),
               discount_percentage: Number(item.discount_percentage) || 0,
               discount_amount: Number(item.discount_amount) || 0,
               tax_percentage: Number(item.tax_percentage) || 0,
-              tax_amount: Number(item.tax_amount) || 0,
+              tax_amount: normalizeInvoiceAmount(Number(item.tax_amount) || 0, documentCurrency, documentRate, documentCurrency, documentRate),
               tax_inclusive: item.tax_inclusive || false,
-              line_total: Number(item.line_total) || 0,
+              line_total: normalizeInvoiceAmount(Number(item.line_total) || 0, documentCurrency, documentRate, documentCurrency, documentRate),
             };
 
             // Recalculate tax to ensure consistency
@@ -430,16 +437,22 @@ export const EditProformaModal = ({
       const totals = calculateTotals();
 
       // Update proforma using the hook
+      const documentCurrency = proforma.currency_code || 'KES';
+      const documentRate = proforma.exchange_rate || 1;
+      const storageMultiplier = documentCurrency === 'USD' ? documentRate : 1;
       const updatedProformaData = {
         customer_id: formData.customer_id,
         proforma_date: formData.proforma_date,
         valid_until: formData.valid_until,
         status: formData.status,
-        subtotal: totals.subtotal,
-        tax_amount: totals.tax_total,
-        total_amount: totals.total_amount,
+        subtotal: totals.subtotal * storageMultiplier,
+        tax_amount: totals.tax_total * storageMultiplier,
+        total_amount: totals.total_amount * storageMultiplier,
         notes: formData.notes,
         terms_and_conditions: formData.terms_and_conditions,
+        currency_code: documentCurrency,
+        exchange_rate: documentRate,
+        fx_date: proforma.fx_date || proforma.proforma_date,
       };
 
       console.log('🔄 SUBMITTING PROFORMA UPDATE', {
@@ -482,6 +495,13 @@ export const EditProformaModal = ({
         qty: i.quantity
       })));
 
+      const persistedItems = validatedItems.map(item => ({
+        ...item,
+        unit_price: item.unit_price * storageMultiplier,
+        tax_amount: item.tax_amount * storageMultiplier,
+        line_total: item.line_total * storageMultiplier,
+      }));
+
       try {
         console.log('🎯 ========================================');
         console.log('🚀 Starting mutation...');
@@ -497,7 +517,7 @@ export const EditProformaModal = ({
         const result = await updateProforma.mutateAsync({
           proformaId: proforma.id,
           proforma: updatedProformaData,
-          items: validatedItems
+          items: persistedItems
         });
 
         console.log('✅ ========================================');

--- a/src/components/receipts/CreateReceiptModal.tsx
+++ b/src/components/receipts/CreateReceiptModal.tsx
@@ -139,14 +139,14 @@ export function CreateReceiptModal({ open, onOpenChange, onSuccess, preSelectedC
       if (newCurrency === currencyCode) return;
       let newRate = 1;
       if (newCurrency === 'USD') {
-        toast.info('Fetching KES→USD rate...');
-        newRate = await getExchangeRate('KES', 'USD', receiptDate);
+        toast.info('Fetching USD/KES rate...');
+        newRate = await getExchangeRate('USD', 'KES', receiptDate);
         if (!newRate || newRate <= 0) throw new Error('Invalid rate');
-        toast.success(`Rate locked: 1 KES = ${newRate.toFixed(6)} USD`);
+        toast.success(`Rate locked: 1 USD = ${newRate.toFixed(2)} KES`);
       } else {
         newRate = 1;
       }
-      const factor = newRate / previousRateRef.current;
+      const factor = previousRateRef.current / newRate;
       convertItemsByFactor(factor);
       previousRateRef.current = newRate;
       setExchangeRate(newRate);
@@ -160,13 +160,13 @@ export function CreateReceiptModal({ open, onOpenChange, onSuccess, preSelectedC
   const fetchAndSetRate = async () => {
     try {
       toast.info('Fetching exchange rate...');
-      const rate = await getExchangeRate('KES', currencyCode, receiptDate);
-      if (!rate || rate <= 0) throw new Error('Invalid exchange rate');
-      const factor = rate / exchangeRate;
+      const newRate = currencyCode === 'USD' ? await getExchangeRate('USD', 'KES', receiptDate) : 1;
+      if (!newRate || newRate <= 0) throw new Error('Invalid exchange rate');
+      const factor = exchangeRate / newRate;
       convertItemsByFactor(factor);
-      previousRateRef.current = rate;
-      setExchangeRate(rate);
-      toast.success(`Rate updated: 1 KES = ${rate.toFixed(6)} ${currencyCode}`);
+      previousRateRef.current = newRate;
+      setExchangeRate(newRate);
+      toast.success(currencyCode === 'USD' ? `Rate updated: 1 USD = ${newRate.toFixed(2)} KES` : 'Currency set to KES');
     } catch (e: any) {
       console.error('Failed to fetch rate:', e);
       toast.error(e?.message || 'Failed to fetch exchange rate');
@@ -186,7 +186,7 @@ export function CreateReceiptModal({ open, onOpenChange, onSuccess, preSelectedC
       console.warn('Product price missing or invalid for product:', product);
       toast.warning(`Product "${product.name}" has no price set`);
     }
-    const price = currencyCode === 'USD' ? priceBase * exchangeRate : priceBase;
+    const price = currencyCode === 'USD' ? priceBase / exchangeRate : priceBase;
 
     const newItem: ReceiptItem = {
       id: `temp-${Date.now()}`,
@@ -379,13 +379,12 @@ export function CreateReceiptModal({ open, onOpenChange, onSuccess, preSelectedC
       let effectiveRate = exchangeRate;
       if (currencyCode === 'USD' && (!Number.isFinite(effectiveRate) || effectiveRate <= 0 || effectiveRate === 1)) {
         toast.info('Locking exchange rate for receipt date...');
-        effectiveRate = await getExchangeRate('KES', 'USD', receiptDate);
+        effectiveRate = await getExchangeRate('USD', 'KES', receiptDate);
         if (!effectiveRate || effectiveRate <= 0) {
           throw new Error('Unable to fetch exchange rate for the selected date');
         }
       }
-      const baseRate = (Number.isFinite(exchangeRate) && exchangeRate > 0) ? exchangeRate : 1;
-      const factor = currencyCode === 'USD' ? (effectiveRate / baseRate) : 1;
+      const factor = 1;
 
       const adjustedItems = items.map(item => ({
         product_id: item.product_id,

--- a/src/components/receipts/EditReceiptModal.tsx
+++ b/src/components/receipts/EditReceiptModal.tsx
@@ -38,6 +38,7 @@ import { toast } from 'sonner';
 import { getExchangeRate } from '@/utils/exchangeRates';
 import { useCurrency } from '@/contexts/CurrencyContext';
 import { formatCurrency as formatCurrencyUtil } from '@/utils/formatCurrency';
+import { normalizeInvoiceAmount } from '@/utils/currency';
 import { DeleteConfirmationModal } from '@/components/DeleteConfirmationModal';
 
 interface ReceiptItem {
@@ -105,10 +106,12 @@ export function EditReceiptModal({ open, onOpenChange, onSuccess, receipt }: Edi
       setSelectedCustomerId(receipt.customer_id || '');
       setReceiptDate(receipt.invoice_date || '');
       setNotes(receipt.notes || '');
-      setAmountTendered(receipt.paid_amount || 0);
-      setCurrencyCode(receipt.currency_code || 'KES');
-      setExchangeRate(receipt.exchange_rate || 1);
-      previousRateRef.current = receipt.exchange_rate || 1;
+      const documentCurrency = receipt.currency_code || 'KES';
+      const documentRate = receipt.exchange_rate || 1;
+      setAmountTendered(normalizeInvoiceAmount(receipt.paid_amount || 0, documentCurrency, documentRate, documentCurrency, documentRate));
+      setCurrencyCode(documentCurrency);
+      setExchangeRate(documentRate);
+      previousRateRef.current = documentRate;
 
       const receiptItems = (receipt.invoice_items || []).map((item: any, index: number) => ({
         id: item.id || `existing-${index}`,
@@ -116,12 +119,12 @@ export function EditReceiptModal({ open, onOpenChange, onSuccess, receipt }: Edi
         product_name: item.products?.name || item.product_name || 'Unknown Product',
         description: item.description || '',
         quantity: item.quantity || 0,
-        unit_price: item.unit_price || 0,
+        unit_price: normalizeInvoiceAmount(item.unit_price || 0, documentCurrency, documentRate, documentCurrency, documentRate),
         discount_before_vat: item.discount_before_vat || 0,
         tax_percentage: item.tax_percentage || 16,
-        tax_amount: item.tax_amount || 0,
+        tax_amount: normalizeInvoiceAmount(item.tax_amount || 0, documentCurrency, documentRate, documentCurrency, documentRate),
         tax_inclusive: item.tax_inclusive || false,
-        line_total: item.line_total || 0,
+        line_total: normalizeInvoiceAmount(item.line_total || 0, documentCurrency, documentRate, documentCurrency, documentRate),
       }));
       
       setItems(receiptItems);
@@ -135,14 +138,14 @@ export function EditReceiptModal({ open, onOpenChange, onSuccess, receipt }: Edi
       if (newCurrency === currencyCode) return;
       let newRate = 1;
       if (newCurrency === 'USD') {
-        toast.info('Fetching KES→USD rate...');
-        newRate = await getExchangeRate('KES', 'USD', receiptDate);
+        toast.info('Fetching USD/KES rate...');
+        newRate = await getExchangeRate('USD', 'KES', receiptDate);
         if (!newRate || newRate <= 0) throw new Error('Invalid rate');
-        toast.success(`Rate locked: 1 KES = ${newRate.toFixed(6)} USD`);
+        toast.success(`Rate locked: 1 USD = ${newRate.toFixed(2)} KES`);
       } else {
         newRate = 1;
       }
-      const factor = newRate / previousRateRef.current;
+      const factor = previousRateRef.current / newRate;
       convertItemsByFactor(factor);
       previousRateRef.current = newRate;
       setExchangeRate(newRate);
@@ -375,7 +378,7 @@ export function EditReceiptModal({ open, onOpenChange, onSuccess, receipt }: Edi
         notes: notes,
         currency_code: currencyCode,
         exchange_rate: currencyCode === 'USD' ? exchangeRate : 1,
-        fx_date: receiptDate,
+        fx_date: currencyCode === receipt.currency_code ? receipt.fx_date || receiptDate : receiptDate,
         terms_and_conditions: ''
       };
 
@@ -423,7 +426,7 @@ export function EditReceiptModal({ open, onOpenChange, onSuccess, receipt }: Edi
           created_by: profile?.id,
           currency_code: currencyCode,
           exchange_rate: currencyCode === 'USD' ? exchangeRate : 1,
-          fx_date: receiptDate,
+          fx_date: currencyCode === receipt.currency_code ? receipt.fx_date || receiptDate : receiptDate,
           terms_and_conditions: ''
         };
 


### PR DESCRIPTION
### Summary
Fixes incorrect currency conversion logic and exchange-rate handling in credit notes, proformas, and receipts so USD amounts are calculated and persisted consistently with the invoice currency contract.

### Problem
Several document flows converted amounts using the wrong rate direction or wrong source/target currency pairs (e.g. fetching `KES→USD` instead of `USD→KES`), and some flows did not normalize persisted or edited amounts against the document's locked exchange rate. This risked incorrect totals when creating or editing USD documents, and stale line-item values when reopening documents for editing.

### Solution
Corrected the exchange rate fetch direction and conversion math across credit note, proforma, and receipt modals, and applied the shared `normalizeInvoiceAmount` helper to consistently convert stored amounts using the document's persisted currency and locked rate.

### Key Changes
- **CreateCreditNoteModal.tsx**: Fixed `formatCurrency` to use `format` directly instead of double-converting; corrected `getExchangeRate` call to `USD→KES`; simplified item/subtotal/tax/total conversion to multiply by the locked rate instead of using `convertAmount`.
- **EditProformaModal.tsx**: Added `currency_code`, `exchange_rate`, and `fx_date` to the `Proforma` interface; normalized loaded item amounts (unit price, tax, line total) using `normalizeInvoiceAmount`; applied a `storageMultiplier` to convert subtotal/tax/total and line items back to KES for storage; persisted currency metadata on update.
- **CreateReceiptModal.tsx**: Fixed exchange rate fetch direction (`USD→KES`), corrected conversion factor calculations (inverted) when switching currency or refreshing rate, fixed product price conversion when adding items, and simplified the submit-time conversion factor to `1` since amounts are already in the correct currency.
- **EditReceiptModal.tsx**: Normalized loaded `paid_amount` and item amounts using `normalizeInvoiceAmount` with the receipt's persisted currency/rate; fixed exchange rate fetch direction and conversion factor on currency change; preserved the original `fx_date` when the currency is unchanged instead of always overwriting it with the current date.


---

<a href="https://builder.io/app/projects/52074d8203d64ed6987f/mesh-crossing-qxu0ovi3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://52074d8203d64ed6987f-mesh-crossing-qxu0ovi3.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=52074d8203d64ed6987f&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 88`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>52074d8203d64ed6987f</projectId>-->
<!--<branchName>mesh-crossing-qxu0ovi3</branchName>-->