### PR TITLE
Fix currency normalization for credit notes, proformas, and receipts

### DIFF
--- a/src/components/credit-notes/ApplyCreditNoteModal.tsx
+++ b/src/components/credit-notes/ApplyCreditNoteModal.tsx
@@ -54,7 +54,7 @@ export function ApplyCreditNoteModal({
   const applyCreditNoteMutation = useApplyCreditNoteToInvoice();
   const { user } = useAuth();
 
-  const { currency, rate, format } = useCurrency();
+  const { rate, format } = useCurrency();
 
   // Filter invoices for the same customer with outstanding balance
   const availableInvoices = invoices.filter(inv => 
@@ -89,12 +89,20 @@ export function ApplyCreditNoteModal({
 
   if (!creditNote) return null;
 
-  const fmtCredit = (amount: number) => format(
-    normalizeInvoiceAmount(Number(amount) || 0, (creditNote as any)?.currency_code as any, (creditNote as any)?.exchange_rate as any, currency, rate)
-  );
-  const fmtInvoice = (amount: number, inv?: any) => format(
-    normalizeInvoiceAmount(Number(amount) || 0, (inv as any)?.currency_code as any, (inv as any)?.exchange_rate as any, currency, rate)
-  );
+  const fmtCredit = (amount: number) => {
+    const documentCurrency = creditNote?.currency_code || 'KES';
+    return format(
+      normalizeInvoiceAmount(Number(amount) || 0, documentCurrency, creditNote?.exchange_rate, documentCurrency, rate),
+      documentCurrency
+    );
+  };
+  const fmtInvoice = (amount: number, invoice?: any) => {
+    const documentCurrency = invoice?.currency_code || 'KES';
+    return format(
+      normalizeInvoiceAmount(Number(amount) || 0, documentCurrency, invoice?.exchange_rate, documentCurrency, rate),
+      documentCurrency
+    );
+  };
 
   const handleAmountChange = (value: string) => {
     const numValue = parseFloat(value) || 0;

--- a/src/components/credit-notes/ViewCreditNoteModal.tsx
+++ b/src/components/credit-notes/ViewCreditNoteModal.tsx
@@ -36,11 +36,13 @@ interface ViewCreditNoteModalProps {
 export function ViewCreditNoteModal({ open, onOpenChange, creditNote, onDelete }: ViewCreditNoteModalProps) {
   const downloadPDF = useCreditNotePDFDownload();
 
-  const { currency, rate, format } = useCurrency();
+  const { rate, format } = useCurrency();
 
   if (!creditNote) return null;
+  const documentCurrency = creditNote.currency_code || 'KES';
   const fmt = (amount: number) => format(
-    normalizeInvoiceAmount(Number(amount) || 0, (creditNote as any).currency_code as any, (creditNote as any).exchange_rate as any, currency, rate)
+    normalizeInvoiceAmount(Number(amount) || 0, documentCurrency, creditNote.exchange_rate, documentCurrency, rate),
+    documentCurrency
   );
 
   const getStatusColor = (status: string) => {

--- a/src/components/proforma/CreateProformaModal.tsx
+++ b/src/components/proforma/CreateProformaModal.tsx
@@ -308,7 +308,15 @@ export const CreateProformaModal = ({
       }));
       const totals = calculateDocumentTotals(taxableItems);
 
-      // Create proforma invoice using the correct table
+      const storageMultiplier = currency === 'USD' ? rate : 1;
+      const storedItems = itemsToSubmit.map(item => ({
+        ...item,
+        unit_price: Number(item.unit_price) * storageMultiplier,
+        discount_amount: Number(item.discount_amount || 0) * storageMultiplier,
+        tax_amount: Number(item.tax_amount || 0) * storageMultiplier,
+        line_total: Number(item.line_total) * storageMultiplier,
+      }));
+
       const proformaData = {
         company_id: companyId,
         customer_id: formData.customer_id,
@@ -316,20 +324,19 @@ export const CreateProformaModal = ({
         proforma_date: formData.proforma_date,
         valid_until: formData.valid_until,
         status: 'draft',
-        subtotal: totals.subtotal,
-        tax_amount: totals.tax_total,
-        total_amount: totals.total_amount,
+        subtotal: totals.subtotal * storageMultiplier,
+        tax_amount: totals.tax_total * storageMultiplier,
+        total_amount: totals.total_amount * storageMultiplier,
         notes: formData.notes,
         terms_and_conditions: formData.terms_and_conditions,
         currency_code: currency,
-        exchange_rate: currency === 'USD' ? rate : 1,
+        exchange_rate: storageMultiplier,
         fx_date: formData.proforma_date
       };
 
-      // Create proforma in database
       await createProforma.mutateAsync({
         proforma: proformaData,
-        items: itemsToSubmit
+        items: storedItems
       });
 
       toast.success('Proforma invoice created successfully!');

--- a/src/hooks/useOptimizedInvoices.ts
+++ b/src/hooks/useOptimizedInvoices.ts
@@ -19,6 +19,7 @@ export interface OptimizedInvoice {
   terms_and_conditions?: string;
   currency_code?: 'KES' | 'USD';
   exchange_rate?: number;
+  fx_date?: string;
   lpo_number?: string;
   created_at?: string;
   updated_at?: string;
@@ -125,6 +126,7 @@ export const useOptimizedInvoices = (
           terms_and_conditions,
           currency_code,
           exchange_rate,
+          fx_date,
           lpo_number,
           created_at,
           updated_at

--- a/src/pages/Invoices.tsx
+++ b/src/pages/Invoices.tsx
@@ -82,6 +82,7 @@ interface Invoice {
   invoice_items?: any[];
   currency_code?: 'KES' | 'USD';
   exchange_rate?: number;
+  fx_date?: string;
 }
 
 function getStatusColor(status: string) {

--- a/src/pages/Payments.tsx
+++ b/src/pages/Payments.tsx
@@ -163,7 +163,7 @@ export default function Payments() {
         logo_url: currentCompany.logo_url
       } : undefined;
 
-      generatePaymentReceiptPDF({ ...payment, currency_code: 'KES' }, companyDetails);
+      generatePaymentReceiptPDF(payment, companyDetails);
       toast.success(`Receipt downloaded for payment ${payment.payment_number}`);
     } catch (error) {
       console.error('Error downloading receipt:', error);

--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -1938,42 +1938,49 @@ export const generateCustomerStatementPDF = async (customer: any, invoices: any[
 };
 
 // Function for generating payment receipt PDF
-export const generatePaymentReceiptPDF = async (payment: any, company?: CompanyDetails) => {
+export const generatePaymentReceiptPDF = async (payment: any, company?: CompanyDetails, currentRate: number = 1) => {
+  const receiptCurrencyCode = payment.currency_code === 'USD' || payment.currency_code === 'KES'
+    ? payment.currency_code
+    : (Number(payment.exchange_rate) && Number(payment.exchange_rate) !== 1 ? 'USD' : 'KES');
+  const receiptRate = Number.isFinite(payment.exchange_rate) ? payment.exchange_rate : currentRate;
+  const normalizeReceiptAmount = (amount: number) => normalizeInvoiceAmount(Number(amount) || 0, receiptCurrencyCode, receiptRate, receiptCurrencyCode, currentRate);
   const allocations = payment.payment_allocations || [];
   const items = allocations.length > 0
     ? allocations.map((alloc: any, idx: number) => ({
         description: `Payment to Invoice ${alloc.invoice_number || alloc.invoice_id || 'N/A'}`,
         quantity: 1,
-        unit_price: Number(alloc.allocated_amount || alloc.amount_allocated || alloc.amount || 0),
+        unit_price: normalizeReceiptAmount(alloc.allocated_amount || alloc.amount_allocated || alloc.amount || 0),
         tax_percentage: 0,
         tax_amount: 0,
         tax_inclusive: false,
-        line_total: Number(alloc.allocated_amount || alloc.amount_allocated || alloc.amount || 0),
+        line_total: normalizeReceiptAmount(alloc.allocated_amount || alloc.amount_allocated || alloc.amount || 0),
       }))
     : [{
         description: `Payment received${payment.reference_number ? ` (Ref: ${payment.reference_number})` : ''}`,
         quantity: 1,
-        unit_price: typeof payment.amount === 'string'
+        unit_price: normalizeReceiptAmount(typeof payment.amount === 'string'
           ? parseFloat(payment.amount.replace('$', '').replace(',', ''))
-          : Number(payment.amount || 0),
+          : Number(payment.amount || 0)),
         tax_percentage: 0,
         tax_amount: 0,
         tax_inclusive: false,
-        line_total: typeof payment.amount === 'string'
+        line_total: normalizeReceiptAmount(typeof payment.amount === 'string'
           ? parseFloat(payment.amount.replace('$', '').replace(',', ''))
-          : Number(payment.amount || 0),
+          : Number(payment.amount || 0)),
       }];
 
-  const totalAmount = typeof payment.amount === 'string'
+  const totalAmount = normalizeReceiptAmount(typeof payment.amount === 'string'
     ? parseFloat(payment.amount.replace('$', '').replace(',', ''))
-    : Number(payment.amount || 0);
+    : Number(payment.amount || 0));
 
   const documentData: DocumentData = {
     type: 'receipt', // Use receipt type for payment receipts
     number: payment.number || payment.payment_number || `REC-${Date.now()}`,
     date: payment.date || payment.payment_date || new Date().toISOString().split('T')[0],
     company: company, // Pass company details
-    currency_code: (payment.currency_code === 'USD' || payment.currency_code === 'KES' ? payment.currency_code : (Number(payment.exchange_rate) && Number(payment.exchange_rate) !== 1 ? 'USD' : 'KES')),
+    currency_code: receiptCurrencyCode,
+    exchange_rate: payment.exchange_rate,
+    fx_date: payment.fx_date,
     customer: {
       name: payment.customer || payment.customers?.name || 'Unknown Customer',
       email: payment.customers?.email,


### PR DESCRIPTION
### Summary
Fixes currency amount formatting and storage across credit notes, proformas, and payment receipts to consistently use each document's own persisted currency and locked exchange rate.

### Problem
Several document views and creation flows were normalizing monetary amounts against the globally selected currency instead of the document's own stored currency and rate, causing amounts to be recalculated with the wrong rate. Proforma creation also stored line items and totals in the entered currency instead of converting USD-entered values to KES for storage. Payment receipt PDFs lacked exchange rate and FX date metadata.

### Solution
Updated formatting helpers in credit note components to normalize and display amounts using each record's own `currency_code`/`exchange_rate` rather than the active global currency, and updated proforma creation to convert USD amounts to KES before persisting. Extended invoice types/queries and the payment receipt PDF generator to carry and use exchange rate/FX date metadata.

### Key Changes
- `ApplyCreditNoteModal.tsx` / `ViewCreditNoteModal.tsx`: format amounts using the credit note's/invoice's own `currency_code` and `exchange_rate` instead of the globally selected currency, passing the document currency to `format` explicitly.
- `CreateProformaModal.tsx`: convert line item unit prices, discounts, tax, and line totals, plus subtotal/tax/total, to KES using the locked exchange rate before submitting when currency is USD.
- `useOptimizedInvoices.ts` and `Invoices.tsx`: add `fx_date` to the `OptimizedInvoice` interface and Supabase select query.
- `pdfGenerator.ts` (`generatePaymentReceiptPDF`): accept a `currentRate` parameter, derive the receipt's currency/rate, normalize allocation and payment amounts with `normalizeInvoiceAmount`, and include `exchange_rate`/`fx_date` in the generated document data.
- `Payments.tsx`: pass the payment object directly to `generatePaymentReceiptPDF` instead of forcing `currency_code: 'KES'`.


---

<a href="https://builder.io/app/projects/7ea356582368475fbea8/mage-continent-kwna3nsp"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://7ea356582368475fbea8-mage-continent-kwna3nsp.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=7ea356582368475fbea8&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 89`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7ea356582368475fbea8</projectId>-->
<!--<branchName>mage-continent-kwna3nsp</branchName>-->