### PR TITLE
Fix currency precision to two decimal places in sales modals

### DIFF
--- a/src/components/invoices/EditInvoiceModal.tsx
+++ b/src/components/invoices/EditInvoiceModal.tsx
@@ -95,8 +95,8 @@ export function EditInvoiceModal({ open, onOpenChange, onSuccess, invoice }: Edi
     return new Intl.NumberFormat(getLocaleForCurrency(currencyCode as any), {
       style: 'currency',
       currency: currencyCode,
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 0,
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
     }).format(Number.isFinite(normalized) ? normalized : 0);
   };
 

--- a/src/components/quotations/ViewQuotationModal.tsx
+++ b/src/components/quotations/ViewQuotationModal.tsx
@@ -280,7 +280,7 @@ export function ViewQuotationModal({
                 {quotation.exchange_rate && quotation.exchange_rate !== 1 && (
                   <div className="flex justify-between">
                     <span className="text-muted-foreground">Exchange Rate:</span>
-                    <span>{quotation.exchange_rate.toFixed(6)}</span>
+                    <span>{quotation.exchange_rate.toFixed(4)}</span>
                   </div>
                 )}
                 <div className="flex justify-between">

--- a/src/contexts/CurrencyContext.tsx
+++ b/src/contexts/CurrencyContext.tsx
@@ -64,8 +64,8 @@ export function CurrencyProvider({ children }: { children: React.ReactNode }) {
     return new Intl.NumberFormat(getLocaleForCurrency(code), {
       style: 'currency',
       currency: code,
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 0,
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
     }).format(Number.isFinite(amount) ? amount : 0);
   };
 

--- a/src/utils/taxCalculation.ts
+++ b/src/utils/taxCalculation.ts
@@ -202,7 +202,12 @@ export function convertToTaxInclusive(exclusivePrice: number, taxPercentage: num
  */
 export function formatCurrency(amount: number, locale: string = 'en-KE', currency: string = 'KES'): string {
   try {
-    return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(amount);
+    return new Intl.NumberFormat(locale, {
+      style: 'currency',
+      currency,
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(amount);
   } catch {
     return `KSh ${amount.toFixed(2)}`;
   }


### PR DESCRIPTION
### Summary
Standardizes currency formatting across sales-related modals and utilities to consistently display two decimal places.

### Problem
Currency amounts in various modals under the sales menu (invoices, quotations, and shared currency/tax utilities) were rendered with zero decimal places, causing amounts to display as whole numbers instead of precise monetary values.

### Solution
Updated the `Intl.NumberFormat` configuration in the affected components and utilities to enforce `minimumFractionDigits: 2` and `maximumFractionDigits: 2`. Also adjusted exchange rate display precision for consistency.

### Key Changes
- `EditInvoiceModal.tsx`: Currency formatter now uses 2 decimal places instead of 0.
- `ViewQuotationModal.tsx`: Exchange rate display precision reduced from 6 to 4 decimal places.
- `CurrencyContext.tsx`: Global currency formatting helper updated to use 2 decimal places.
- `taxCalculation.ts`: `formatCurrency` utility updated to explicitly enforce 2 decimal places in the `Intl.NumberFormat` options.


---

<a href="https://builder.io/app/projects/dd207ca2175a45fb9c19/septa-ship-u3qxbplu"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://dd207ca2175a45fb9c19-septa-ship-u3qxbplu.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=dd207ca2175a45fb9c19&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 91`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>dd207ca2175a45fb9c19</projectId>-->
<!--<branchName>septa-ship-u3qxbplu</branchName>-->