### PR TITLE
Fix login redirect loop and currency rounding in proforma invoices

### DIFF
--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -46,6 +46,14 @@ export function ProtectedRoute({
     return () => clearTimeout(t);
   }, [hasSupabaseToken]);
 
+  const shouldRedirect = requireAuth && !loading && !isAuthenticated && !grace;
+
+  useEffect(() => {
+    if (shouldRedirect) {
+      navigate('/login', { replace: true });
+    }
+  }, [navigate, shouldRedirect]);
+
   // Show loading while initializing or during grace period to allow session restore
   if (loading || (requireAuth && !isAuthenticated && grace)) {
     return (
@@ -59,12 +67,7 @@ export function ProtectedRoute({
   }
 
   // Check authentication - redirect to login if not authenticated
-  if (requireAuth && !isAuthenticated) {
-    // Redirect to login page
-    useEffect(() => {
-      navigate('/login', { replace: true });
-    }, [navigate]);
-
+  if (shouldRedirect) {
     return fallback || (
       <div className="flex items-center justify-center min-h-[400px]">
         <div className="text-center">

--- a/src/components/proforma/CreateProformaModalOptimized.tsx
+++ b/src/components/proforma/CreateProformaModalOptimized.tsx
@@ -39,7 +39,7 @@ import { useNewItemsAutoSave } from '@/hooks/useNewItemsAutoSave';
 import { DeleteConfirmationModal } from '@/components/DeleteConfirmationModal';
 import { generateNextProformaNumber } from '@/utils/improvedProformaFix';
 import { getExchangeRate, getLocaleForCurrency } from '@/utils/exchangeRates';
-import { convertAmount } from '@/utils/currency';
+import { round } from '@/utils/currency';
 
 interface ProformaItem {
   id: string;
@@ -122,9 +122,14 @@ export const CreateProformaModalOptimized = ({
 
   const convertItemsByFactor = (factor: number) => {
     setItems(prev => prev.map(item => {
-      const newUnit = parseFloat((item.unit_price * factor).toFixed(4));
+      const newUnit = round(item.unit_price * factor);
       const calculated = calculateItemTax({ ...item, unit_price: newUnit });
-      return { ...item, unit_price: newUnit, line_total: calculated.line_total, tax_amount: calculated.tax_amount };
+      return {
+        ...item,
+        unit_price: newUnit,
+        line_total: round(calculated.line_total),
+        tax_amount: round(calculated.tax_amount),
+      };
     }));
   };
 
@@ -217,7 +222,9 @@ export const CreateProformaModalOptimized = ({
         product_name: product.name,
         description: product.description || '',
         quantity: 1,
-        unit_price: currencyCode === 'USD' && exchangeRate > 1 ? (product.selling_price || 0) / exchangeRate : (product.selling_price || 0),
+        unit_price: round(currencyCode === 'USD' && exchangeRate > 1
+          ? (product.selling_price || 0) / exchangeRate
+          : (product.selling_price || 0)),
         discount_percentage: 0,
         discount_amount: 0,
         tax_percentage: defaultTaxRate,
@@ -262,7 +269,8 @@ export const CreateProformaModalOptimized = ({
   const updateItem = (id: string, field: keyof ProformaItem, value: any) => {
     setItems(prev => prev.map(item => {
       if (item.id === id) {
-        let updatedItem = { ...item, [field]: value };
+        const normalizedValue = field === 'unit_price' ? round(Number(value)) : value;
+        const updatedItem = { ...item, [field]: normalizedValue };
 
         // Special handling for tax_inclusive checkbox
         if (field === 'tax_inclusive') {
@@ -449,7 +457,7 @@ export const CreateProformaModalOptimized = ({
       // Calculate totals using the items that will be submitted
       const taxableItems: TaxableItem[] = itemsToSubmit.map(item => ({
         quantity: item.quantity,
-        unit_price: item.unit_price,
+        unit_price: round(item.unit_price),
         tax_percentage: item.tax_percentage,
         tax_inclusive: item.tax_inclusive,
         discount_percentage: item.discount_percentage,
@@ -463,13 +471,13 @@ export const CreateProformaModalOptimized = ({
         product_name: item.product_name,
         description: item.description,
         quantity: item.quantity,
-        unit_price: currencyCode === 'USD' ? Number(item.unit_price) * effectiveRate : Number(item.unit_price),
+        unit_price: round(currencyCode === 'USD' ? Number(item.unit_price) * effectiveRate : Number(item.unit_price)),
         discount_percentage: item.discount_percentage || 0,
-        discount_amount: item.discount_amount || 0,
+        discount_amount: round(item.discount_amount || 0),
         tax_percentage: item.tax_percentage,
-        tax_amount: currencyCode === 'USD' ? Number(item.tax_amount || 0) * effectiveRate : Number(item.tax_amount || 0),
+        tax_amount: round(currencyCode === 'USD' ? Number(item.tax_amount || 0) * effectiveRate : Number(item.tax_amount || 0)),
         tax_inclusive: item.tax_inclusive,
-        line_total: currencyCode === 'USD' ? Number(item.line_total) * effectiveRate : Number(item.line_total)
+        line_total: round(currencyCode === 'USD' ? Number(item.line_total) * effectiveRate : Number(item.line_total))
       }));
 
       // Create proforma invoice using the correct table
@@ -480,9 +488,9 @@ export const CreateProformaModalOptimized = ({
         proforma_date: formData.proforma_date,
         valid_until: formData.valid_until,
         status: 'draft',
-        subtotal: currencyCode === 'USD' ? totals.subtotal * effectiveRate : totals.subtotal,
-        tax_amount: currencyCode === 'USD' ? totals.tax_total * effectiveRate : totals.tax_total,
-        total_amount: currencyCode === 'USD' ? totals.total_amount * effectiveRate : totals.total_amount,
+        subtotal: round(currencyCode === 'USD' ? totals.subtotal * effectiveRate : totals.subtotal),
+        tax_amount: round(currencyCode === 'USD' ? totals.tax_total * effectiveRate : totals.tax_total),
+        total_amount: round(currencyCode === 'USD' ? totals.total_amount * effectiveRate : totals.total_amount),
         notes: formData.notes,
         terms_and_conditions: formData.terms_and_conditions,
         currency_code: currencyCode,


### PR DESCRIPTION
### Summary
Fixes an authentication redirect bug in `ProtectedRoute` and rounds currency-converted values in the proforma invoice creation flow to two decimal places.

### Problem
When creating a proforma invoice and selecting the dollar currency, users were incorrectly redirected to the login page on the first attempt, requiring a second attempt to succeed. Additionally, unit prices converted between currencies (e.g., to USD) displayed with excessive decimal precision (e.g., `139.91200617004216`) instead of the expected two decimal places.

### Solution
Refactored `ProtectedRoute` to compute the redirect condition once and consistently, moving the `useEffect` call out of a conditional branch so it always runs and avoids violating React's rules of hooks. In the proforma modal, replaced ad-hoc `toFixed` and raw multiplication with a shared `round` utility applied consistently across unit prices, line totals, tax amounts, and invoice totals.

### Key Changes
- `ProtectedRoute.tsx`: Introduced a `shouldRedirect` flag combining `requireAuth`, `loading`, `isAuthenticated`, and `grace` state, and moved the login redirect `useEffect` to the top level of the component instead of inside a conditional block.
- `CreateProformaModalOptimized.tsx`: Replaced `convertAmount` import with `round` from `@/utils/currency`.
- Applied `round()` when converting item unit prices by exchange rate factor (`convertItemsByFactor`).
- Applied `round()` when setting initial unit price for newly added products based on currency/exchange rate.
- Applied `round()` to `unit_price` updates in `updateItem` when the field being changed is `unit_price`.
- Applied `round()` to submitted item values: `unit_price`, `discount_amount`, `tax_amount`, and `line_total`.
- Applied `round()` to invoice-level `subtotal`, `tax_amount`, and `total_amount` when converting to USD.

---

<a href="https://builder.io/app/projects/ea318af68c5442d69d11/meta-department-xyzghvjh"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ea318af68c5442d69d11-meta-department-xyzghvjh.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=ea318af68c5442d69d11&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 92`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ea318af68c5442d69d11</projectId>-->
<!--<branchName>meta-department-xyzghvjh</branchName>-->